### PR TITLE
Enable machine status and resource names queries only when robot client is defined

### DIFF
--- a/.changeset/eighty-singers-fall.md
+++ b/.changeset/eighty-singers-fall.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/svelte-sdk': patch
+---
+
+Enable machine status and resource names queries only when robot client is defined

--- a/src/lib/compare.ts
+++ b/src/lib/compare.ts
@@ -34,6 +34,7 @@ export const isJsonEqual = (object1: object, object2: object) => {
       return false;
     }
   }
+
   return true;
 };
 

--- a/src/lib/hooks/machine-status.svelte.ts
+++ b/src/lib/hooks/machine-status.svelte.ts
@@ -24,10 +24,14 @@ export const provideMachineStatusContext = (refetchInterval: () => number) => {
   const options = $derived(
     Object.entries(clients.current).map(([partID, client]) => {
       return queryOptions({
+        enabled: client !== undefined,
         queryKey: ['partID', partID, 'robotClient', 'machineStatus'],
         refetchInterval: refetchInterval(),
-        queryFn: async () => {
-          return client?.getMachineStatus();
+        queryFn: async (): Promise<MachineStatus> => {
+          if (!client) {
+            throw new Error('No client');
+          }
+          return client.getMachineStatus();
         },
       });
     })
@@ -38,7 +42,6 @@ export const provideMachineStatusContext = (refetchInterval: () => number) => {
       queries: toStore(() => options),
       combine: (results) => {
         const partIDs = Object.keys(clients.current);
-
         return Object.fromEntries(
           results.map((result, index) => [partIDs[index], result])
         );

--- a/src/lib/hooks/resource-names.svelte.ts
+++ b/src/lib/hooks/resource-names.svelte.ts
@@ -1,5 +1,6 @@
 import {
   createQueries,
+  queryOptions,
   type QueryObserverResult,
 } from '@tanstack/svelte-query';
 import type { ResourceName } from '@viamrobotics/sdk';
@@ -33,13 +34,16 @@ export const provideResourceNamesContext = () => {
       const revision =
         machineStatuses.current[partID]?.data?.config?.revision ?? '';
 
-      return {
+      return queryOptions({
+        enabled: client !== undefined,
         queryKey: ['partID', partID, 'robotClient', 'resourceNames', revision],
         queryFn: async () => {
-          if (!client) return [];
+          if (!client) {
+            throw new Error('No client');
+          }
           return client.resourceNames();
         },
-      };
+      });
     })
   );
 


### PR DESCRIPTION
Fixes a few annoying warnings I noticed during usage.