### PR TITLE
Memoize useResourceNames results

### DIFF
--- a/.changeset/clear-eyes-battle.md
+++ b/.changeset/clear-eyes-battle.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/svelte-sdk': patch
+---
+
+Memoize useResourceNames results

--- a/src/lib/hooks/resource-names.svelte.ts
+++ b/src/lib/hooks/resource-names.svelte.ts
@@ -68,6 +68,7 @@ export const provideResourceNamesContext = () => {
   const machineStatuses = useMachineStatuses();
   const clients = useRobotClients();
 
+  const partIDs = $derived(Object.keys(clients.current));
   const options = $derived(
     Object.entries(clients.current).map(([partID, client]) => {
       return queryOptions({
@@ -105,7 +106,7 @@ export const provideResourceNamesContext = () => {
   $effect(() => {
     let index = 0;
 
-    for (const [partID] of Object.entries(clients.current)) {
+    for (const partID of partIDs) {
       const revision =
         machineStatuses.current[partID]?.data?.config?.revision ?? '';
       const lastRevision = revisions.get(partID);
@@ -121,7 +122,6 @@ export const provideResourceNamesContext = () => {
     }
   });
 
-  const partIDs = $derived(Object.keys(clients.current));
   const current = $derived(
     Object.fromEntries(
       queries.current.map((result, index) => [partIDs[index], result])

--- a/src/lib/hooks/resource-names.svelte.ts
+++ b/src/lib/hooks/resource-names.svelte.ts
@@ -71,6 +71,9 @@ export const provideResourceNamesContext = () => {
     })
   );
 
+  /**
+   * Individually refetch part resource names based on revision
+   */
   $effect(() => {
     let index = 0;
 

--- a/src/lib/hooks/resource-names.svelte.ts
+++ b/src/lib/hooks/resource-names.svelte.ts
@@ -70,7 +70,8 @@ export const provideResourceNamesContext = () => {
 
   const partIDs = $derived(Object.keys(clients.current));
   const options = $derived(
-    Object.entries(clients.current).map(([partID, client]) => {
+    partIDs.map((partID) => {
+      const client = clients.current[partID];
       return queryOptions({
         enabled: client !== undefined,
         queryKey: [

--- a/src/lib/hooks/resource-names.svelte.ts
+++ b/src/lib/hooks/resource-names.svelte.ts
@@ -3,7 +3,7 @@ import {
   queryOptions,
   type QueryObserverResult,
 } from '@tanstack/svelte-query';
-import { ResourceName } from '@viamrobotics/sdk';
+import type { ResourceName } from '@viamrobotics/sdk';
 import { getContext, setContext } from 'svelte';
 import { fromStore, toStore } from 'svelte/store';
 import { useRobotClients } from './robot-clients.svelte';

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,7 +26,6 @@ let dialConfigs = $derived(
   Object.fromEntries(Object.entries(configs).filter(([key]) => enabled[key]))
 );
 
-$inspect(dialConfigs);
 let { children }: Props = $props();
 </script>
 

--- a/src/routes/configs.ts
+++ b/src/routes/configs.ts
@@ -13,5 +13,3 @@ const parseConfigs = () => {
 };
 
 export const dialConfigs: Record<string, DialConf> = parseConfigs();
-
-console.log('what', dialConfigs);

--- a/src/routes/configs.ts
+++ b/src/routes/configs.ts
@@ -13,3 +13,5 @@ const parseConfigs = () => {
 };
 
 export const dialConfigs: Record<string, DialConf> = parseConfigs();
+
+console.log('what', dialConfigs);


### PR DESCRIPTION
### Overview

A few optimizations here: 
1. resourceNames Queries are no longer invalidated, destroying their `data` contents, on reconfigure, they are instead refetched, preserving `data`
2. gives resourceNames a stale time of Infinity to avoid pointless refetches
3. memoizes the results of a resourceNames fetch via an object deep equality check