### PR TITLE
Ensure consistent streamClient and resourceName in stream related effects

### DIFF
--- a/.changeset/whole-snakes-grin.md
+++ b/.changeset/whole-snakes-grin.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/svelte-sdk': patch
+---
+
+Ensure consistent streamClient and resourceName in stream related effects

--- a/src/lib/hooks/create-stream-client.svelte.ts
+++ b/src/lib/hooks/create-stream-client.svelte.ts
@@ -30,13 +30,16 @@ export const createStreamClient = (
   };
 
   $effect(() => {
-    streamClient?.on('track', handleTrack);
-    return () => streamClient?.off('track', handleTrack);
+    const client = streamClient;
+    client?.on('track', handleTrack);
+    return () => client?.off('track', handleTrack);
   });
 
   $effect(() => {
-    streamClient?.getStream(resourceName());
-    return () => streamClient?.remove(resourceName());
+    const name = resourceName();
+    const client = streamClient;
+    client?.getStream(name);
+    return () => client?.remove(name);
   });
 
   const queryOptions = $derived(


### PR DESCRIPTION
This PR caches resourceName and streamClient in effects so that cleanup functions will never unintentionally reference another client or resource.