### PR TITLE
Cancel and reset queries on disconnect

### DIFF
--- a/.changeset/full-zebras-send.md
+++ b/.changeset/full-zebras-send.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/svelte-sdk': patch
+---
+
+Cancel and reset queries on part disconnect

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules
 /.svelte-kit
 /build
 /dist
+viamrobotics-svelte-sdk-*.tgz
 
 # OS
 .DS_Store

--- a/src/lib/hooks/robot-clients.svelte.ts
+++ b/src/lib/hooks/robot-clients.svelte.ts
@@ -81,10 +81,20 @@ export const provideRobotClientsContext = (
 
       const client = await createRobotClient(config);
       (client as RobotClient & { partID: string }).partID = partID;
-      client.on('connectionstatechange', (event) => {
+      client.on('connectionstatechange', async (event) => {
         connectionStatus[partID] = (
           event as { eventType: MachineConnectionEvent }
         ).eventType;
+
+        if (connectionStatus[partID] === MachineConnectionEvent.DISCONNECTED) {
+          await queryClient.cancelQueries({
+            queryKey: ['viam-svelte-sdk', 'partID', partID],
+          });
+
+          await queryClient.resetQueries({
+            queryKey: ['viam-svelte-sdk', 'partID', partID],
+          });
+        }
       });
 
       clients[partID] = client;


### PR DESCRIPTION
I noticed that if a machine disconnected while queries were fetching, they would get stuck in a fetching state and would not reliably restart when the machine reconnects. This change ensures that whenever we detect a disconnect event, we cancel all queries for the part and then reset them to the initial state. 