### PR TITLE
Throw on error when refetching queries for use polling

### DIFF
--- a/.changeset/lucky-boats-smell.md
+++ b/.changeset/lucky-boats-smell.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/svelte-sdk': patch
+---
+
+Throw errors on polling refetch

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@viamrobotics/svelte-sdk",
   "description": "Build Svelte apps with Viam",
   "license": "Apache-2.0",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && npm run prepack",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@viamrobotics/svelte-sdk",
   "description": "Build Svelte apps with Viam",
   "license": "Apache-2.0",
-  "version": "0.4.4",
+  "version": "0.4.3",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && npm run prepack",

--- a/src/lib/hooks/use-polling.svelte.ts
+++ b/src/lib/hooks/use-polling.svelte.ts
@@ -24,7 +24,10 @@ export function usePolling(
     }
 
     const poll = async () => {
-      await queryClient.refetchQueries({ queryKey: key });
+      await queryClient.refetchQueries(
+        { queryKey: key },
+        { throwOnError: true }
+      );
       timeoutId = setTimeout(poll, currentInterval);
     };
 


### PR DESCRIPTION
Noticed while debugging with @benjirewis that tanstack does not throw errors when calling `refetchQueries` by default. Updating our `use-polling` hook to pass `throwOnError: true` when refetching to ensure errors are bubbled up to our handlers.