### PR TITLE
export streamQueryKey factory

### DIFF
--- a/.changeset/cold-beans-sin.md
+++ b/.changeset/cold-beans-sin.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/svelte-sdk': patch
+---
+
+Export streamQueryKey factory to help with query management

--- a/src/lib/hooks/create-resource-stream.svelte.ts
+++ b/src/lib/hooks/create-resource-stream.svelte.ts
@@ -28,6 +28,21 @@ interface QueryOptions {
 
 type QueryResult<U> = QueryObserverResult<U[], Error>;
 
+export const streamQueryKey = (
+  partID: string,
+  name: string | undefined,
+  methodName: string,
+  args?: QueryOptions | unknown
+) => [
+  'viam-svelte-sdk',
+  'partID',
+  partID,
+  'resource',
+  name,
+  methodName,
+  ...(args ? [args] : []),
+];
+
 export const createResourceStream = <T extends Resource, K extends keyof T>(
   client: { current: T | undefined },
   method: K,
@@ -55,15 +70,8 @@ export const createResourceStream = <T extends Resource, K extends keyof T>(
   const name = $derived(client.current?.name);
   const methodName = $derived(String(method));
   const refetchMode = $derived(_options?.refetchMode ?? 'reset');
-  const queryKey = $derived([
-    'viam-svelte-sdk',
-    'partID',
-    (client.current as T & { partID: string })?.partID,
-    'resource',
-    name,
-    methodName,
-    ...(_args ? [_args] : []),
-  ]);
+  const partID = $derived((client.current as T & { partID: string })?.partID);
+  const queryKey = $derived(streamQueryKey(partID, name, methodName, _args));
 
   function processStream() {
     const clientFunc = client.current?.[method];

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -16,7 +16,10 @@ export { createRobotMutation } from './hooks/create-robot-mutation.svelte';
 export { createResourceClient } from './hooks/create-resource-client.svelte';
 export { createResourceQuery } from './hooks/create-resource-query.svelte';
 export { createResourceMutation } from './hooks/create-resource-mutation.svelte';
-export { createResourceStream } from './hooks/create-resource-stream.svelte';
+export {
+  createResourceStream,
+  streamQueryKey,
+} from './hooks/create-resource-stream.svelte';
 export { createStreamClient } from './hooks/create-stream-client.svelte';
 
 export { useMachineStatus } from './hooks/machine-status.svelte';


### PR DESCRIPTION
Added a `streamQueryKey` factory function for both internal use, and to be used to manage queries directly with the query client. For example: for `createResourceStream` we may want to strictly flush old stream events to avoid accumulating them in the tanstack client and causing memory issues.

Here is a practical example for `motion-tools`:

```ts
	$effect.pre(() => {
		if (changeStream.current?.data === undefined) return

		const events = changeStream.current.data.filter((event) => event.transform !== undefined)
		if (events.length === 0) return

		worker.postMessage({ type: 'change', events })

		// clear the stream data to prevent event accumulation and memory issues
		queryClient.setQueryData(streamQueryKey(partID(), resourceName(), 'streamTransformChanges'), [])
	})
```