### PR TITLE
Fix usePolling stopping after deps change while a fetch is in-flight

### DIFF
--- a/.changeset/shaggy-days-float.md
+++ b/.changeset/shaggy-days-float.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/svelte-sdk': patch
+---
+
+Fix usePolling stopping after deps change while a fetch is in-flight

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install and Build 🔧
         run: |

--- a/src/lib/hooks/__tests__/use-polling.svelte.spec.ts
+++ b/src/lib/hooks/__tests__/use-polling.svelte.spec.ts
@@ -251,6 +251,76 @@ describe('usePolling', () => {
     expect(mockRefetchQueries).toHaveBeenCalledTimes(2);
   });
 
+  it('continues polling when deps change while a fetch is in-flight', async () => {
+    // Arrange
+    let resolveRefetch: (() => void) | undefined;
+    mockRefetchQueries.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRefetch = resolve;
+        })
+    );
+
+    const { rerender } = render(UsePollingTestWrapper, {
+      props: { queryKey: ['test'], interval: 1000 },
+    });
+
+    // Act - fire first poll, leave it pending
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(mockRefetchQueries).toHaveBeenCalledTimes(1);
+
+    // Act - rerender while fetch is in-flight
+    await rerender({ queryKey: ['test'], interval: 500 });
+
+    // Act - resolve the stale in-flight fetch (from R1)
+    resolveRefetch!();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Switch to resolved mock so the next poll doesn't hang
+    mockRefetchQueries.mockReset();
+    mockRefetchQueries.mockResolvedValue(undefined);
+
+    // Assert - polling from R2 continues at the new interval
+    await vi.advanceTimersByTimeAsync(500);
+    expect(mockRefetchQueries).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(mockRefetchQueries).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not leak pollers across repeated mid-fetch dep changes', async () => {
+    // Arrange - every refetch hangs until manually resolved
+    const resolvers: Array<() => void> = [];
+    mockRefetchQueries.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+
+    const { rerender } = render(UsePollingTestWrapper, {
+      props: { queryKey: ['test'], interval: 1000 },
+    });
+
+    // Fire poll, leave pending, rerender — repeat
+    for (let i = 0; i < 5; i++) {
+      await vi.advanceTimersByTimeAsync(1000);
+      await rerender({ queryKey: ['test'], interval: 1000 });
+    }
+
+    // Resolve every hung fetch; stale polls must not schedule new work
+    for (const resolve of resolvers) resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const callsBefore = mockRefetchQueries.mock.calls.length;
+
+    // Advance far enough that leaked pollers would fire many times
+    await vi.advanceTimersByTimeAsync(1000);
+
+    // Only one live poller should fire
+    expect(mockRefetchQueries.mock.calls.length - callsBefore).toBe(1);
+  });
+
   it('handles slow requests without stacking when request takes longer than interval', async () => {
     // Arrange
     const requestResolvers: Array<() => void> = [];

--- a/src/lib/hooks/use-polling.svelte.ts
+++ b/src/lib/hooks/use-polling.svelte.ts
@@ -16,8 +16,6 @@ export function usePolling(
   interval: () => number | false
 ) {
   const queryClient = useQueryClient();
-  let timeoutId: ReturnType<typeof setTimeout>;
-  let active = true;
 
   $effect(() => {
     const abortController = new AbortController();
@@ -25,17 +23,12 @@ export function usePolling(
     const currentInterval = interval();
     if (!currentInterval) return;
 
-    active = true;
+    let timeoutId: ReturnType<typeof setTimeout>;
 
     const poll = async () => {
-      if (!active) return;
-      if (abortController.signal.aborted) {
-        active = false;
-        clearTimeout(timeoutId);
-        return;
-      }
-
+      if (abortController.signal.aborted) return;
       await queryClient.refetchQueries({ queryKey: key });
+      if (abortController.signal.aborted) return;
       timeoutId = setTimeout(poll, currentInterval);
     };
 
@@ -43,7 +36,6 @@ export function usePolling(
 
     return () => {
       clearTimeout(timeoutId);
-      active = false;
       abortController.abort();
     };
   });


### PR DESCRIPTION
Found by Claude while I was fixing something else 😄  Their summary:

timeoutId and active were declared outside $effect, so they were shared across effect re-runs. When props changed mid-fetch (e.g. queryKey or interval updated while refetchQueries was pending), the stale in-flight poll would resume after cleanup, hit its per-run abortController.signal.aborted check, and call clearTimeout(timeoutId) — but timeoutId now pointed at the new run's timer, killing polling entirely. 

Moved timeoutId inside the effect so each run owns its own, and dropped the redundant active flag in favor of the per-run abortController.signal. Added two tests: one that rerenders while a fetch is pending and asserts polling continues at the new interval, and one that loops rerenders-during-pending-fetch and asserts no poller leak/death.