### PR TITLE
security bump

### DIFF
--- a/.changeset/cuddly-places-juggle.md
+++ b/.changeset/cuddly-places-juggle.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/svelte-sdk': patch
+---
+
+Security updates


### PR DESCRIPTION
Adds a changeset to cut a release with all the recent dependency bumps per security reports.