### PR TITLE
Do not enable queries until machine has connected

### DIFF
--- a/.changeset/slimy-states-ask.md
+++ b/.changeset/slimy-states-ask.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/svelte-sdk': patch
+---
+
+Do not enable queries until machine has connected

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prepack": "svelte-kit sync && svelte-package && publint",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "format": "prettier --write .",
+    "format": "prettier --write . && eslint . --fix",
     "lint": "prettier --check . && eslint . && knip",
     "test:unit": "vitest",
     "test": "npm run test:unit -- --run",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "globals": "^16.5.0",
     "jsdom": "^26.1.0",
     "knip": "^6.7.0",
-    "prettier": "^3.8.3",
+    "prettier": "3.6.2",
     "prettier-plugin-svelte": "^3.5.1",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "publint": "^0.3.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
         version: 5.3.1(svelte@5.53.5(@typescript-eslint/types@8.59.1))(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))(vitest@3.2.4(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(yaml@2.8.3))
       '@viamrobotics/prettier-config-svelte':
         specifier: ^1.1.0
-        version: 1.1.0(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1))(tailwindcss@4.2.4)
+        version: 1.1.0(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1))(tailwindcss@4.2.4)
       '@viamrobotics/sdk':
         specifier: ^0.69.0
         version: 0.69.0
@@ -82,14 +82,14 @@ importers:
         specifier: ^6.7.0
         version: 6.7.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       prettier:
-        specifier: ^3.8.3
-        version: 3.8.3
+        specifier: 3.6.2
+        version: 3.6.2
       prettier-plugin-svelte:
         specifier: ^3.5.1
-        version: 3.5.1(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1))
+        version: 3.5.1(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1))
       prettier-plugin-tailwindcss:
         specifier: ^0.6.14
-        version: 0.6.14(prettier-plugin-svelte@3.5.1(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1)))(prettier@3.8.3)
+        version: 0.6.14(prettier-plugin-svelte@3.5.1(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1)))(prettier@3.6.2)
       publint:
         specifier: ^0.3.18
         version: 0.3.18
@@ -2134,8 +2134,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -3527,12 +3527,12 @@ snapshots:
       '@typescript-eslint/types': 8.59.1
       eslint-visitor-keys: 5.0.1
 
-  '@viamrobotics/prettier-config-svelte@1.1.0(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1))(tailwindcss@4.2.4)':
+  '@viamrobotics/prettier-config-svelte@1.1.0(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1))(tailwindcss@4.2.4)':
     dependencies:
-      '@viamrobotics/prettier-config': 1.0.1(prettier@3.8.3)
-      prettier: 3.8.3
-      prettier-plugin-svelte: 3.3.3(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1))
-      prettier-plugin-tailwindcss: 0.6.14(prettier-plugin-svelte@3.3.3(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1)))(prettier@3.8.3)
+      '@viamrobotics/prettier-config': 1.0.1(prettier@3.6.2)
+      prettier: 3.6.2
+      prettier-plugin-svelte: 3.3.3(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1))
+      prettier-plugin-tailwindcss: 0.6.14(prettier-plugin-svelte@3.3.3(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1)))(prettier@3.6.2)
       svelte: 5.53.5(@typescript-eslint/types@8.59.1)
       tailwindcss: 4.2.4
     transitivePeerDependencies:
@@ -3554,9 +3554,9 @@ snapshots:
       - prettier-plugin-sort-imports
       - prettier-plugin-style-order
 
-  '@viamrobotics/prettier-config@1.0.1(prettier@3.8.3)':
+  '@viamrobotics/prettier-config@1.0.1(prettier@3.6.2)':
     dependencies:
-      prettier: 3.8.3
+      prettier: 3.6.2
 
   '@viamrobotics/sdk@0.69.0':
     dependencies:
@@ -4446,31 +4446,31 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.3.3(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1)):
+  prettier-plugin-svelte@3.3.3(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1)):
     dependencies:
-      prettier: 3.8.3
+      prettier: 3.6.2
       svelte: 5.53.5(@typescript-eslint/types@8.59.1)
 
-  prettier-plugin-svelte@3.5.1(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1)):
+  prettier-plugin-svelte@3.5.1(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1)):
     dependencies:
-      prettier: 3.8.3
+      prettier: 3.6.2
       svelte: 5.53.5(@typescript-eslint/types@8.59.1)
 
-  prettier-plugin-tailwindcss@0.6.14(prettier-plugin-svelte@3.3.3(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1)))(prettier@3.8.3):
+  prettier-plugin-tailwindcss@0.6.14(prettier-plugin-svelte@3.3.3(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1)))(prettier@3.6.2):
     dependencies:
-      prettier: 3.8.3
+      prettier: 3.6.2
     optionalDependencies:
-      prettier-plugin-svelte: 3.3.3(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1))
+      prettier-plugin-svelte: 3.3.3(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1))
 
-  prettier-plugin-tailwindcss@0.6.14(prettier-plugin-svelte@3.5.1(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1)))(prettier@3.8.3):
+  prettier-plugin-tailwindcss@0.6.14(prettier-plugin-svelte@3.5.1(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1)))(prettier@3.6.2):
     dependencies:
-      prettier: 3.8.3
+      prettier: 3.6.2
     optionalDependencies:
-      prettier-plugin-svelte: 3.5.1(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1))
+      prettier-plugin-svelte: 3.5.1(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1))
 
   prettier@2.8.8: {}
 
-  prettier@3.8.3: {}
+  prettier@3.6.2: {}
 
   pretty-format@27.5.1:
     dependencies:

--- a/src/lib/hooks/create-resource-query.svelte.ts
+++ b/src/lib/hooks/create-resource-query.svelte.ts
@@ -3,10 +3,11 @@ import {
   queryOptions as createQueryOptions,
   type QueryObserverResult,
 } from '@tanstack/svelte-query';
-import type { Resource } from '@viamrobotics/sdk';
+import { MachineConnectionEvent, type Resource } from '@viamrobotics/sdk';
 import { usePolling } from './use-polling.svelte';
 import { createQueryLogger } from '$lib/logger';
 import { useEnabledQueries } from './use-enabled-queries.svelte';
+import { useConnectionStatus } from './robot-clients.svelte';
 import type {
   ArgumentsType,
   ResolvedReturnType,
@@ -40,8 +41,11 @@ export const createResourceQuery = <T extends Resource, K extends keyof T>(
   const _args = $derived(typeof args === 'function' ? args() : args);
   const name = $derived(client.current?.name);
   const methodName = $derived(String(method));
+  const partID = $derived((client.current as T & { partID: string })?.partID);
+  const connectionStatus = useConnectionStatus(() => partID);
   const enabled = $derived(
-    client.current !== undefined &&
+    connectionStatus.current === MachineConnectionEvent.CONNECTED &&
+      client.current !== undefined &&
       _options?.enabled !== false &&
       enabledQueries.resourceQueries
   );
@@ -49,7 +53,7 @@ export const createResourceQuery = <T extends Resource, K extends keyof T>(
   const queryKey = $derived([
     'viam-svelte-sdk',
     'partID',
-    (client.current as T & { partID: string })?.partID,
+    partID,
     'resource',
     name,
     methodName,

--- a/src/lib/hooks/create-resource-stream.svelte.ts
+++ b/src/lib/hooks/create-resource-stream.svelte.ts
@@ -4,9 +4,10 @@ import {
   type QueryObserverResult,
   queryOptions as createQueryOptions,
 } from '@tanstack/svelte-query';
-import type { Resource } from '@viamrobotics/sdk';
+import { MachineConnectionEvent, type Resource } from '@viamrobotics/sdk';
 import { createQueryLogger } from '$lib/logger';
 import { useEnabledQueries } from './use-enabled-queries.svelte';
+import { useConnectionStatus } from './robot-clients.svelte';
 import type {
   ArgumentsType,
   StreamItemType,
@@ -58,6 +59,7 @@ export const createResourceStream = <T extends Resource, K extends keyof T>(
   const methodName = $derived(String(method));
   const refetchMode = $derived(_options?.refetchMode ?? 'reset');
   const partID = $derived((client.current as T & { partID: string })?.partID);
+  const connectionStatus = useConnectionStatus(() => partID);
   const queryKey = $derived(streamQueryKey(partID, name, methodName, _args));
 
   function processStream() {
@@ -90,6 +92,7 @@ export const createResourceStream = <T extends Resource, K extends keyof T>(
     createQueryOptions({
       queryKey,
       enabled:
+        connectionStatus.current === MachineConnectionEvent.CONNECTED &&
         client.current !== undefined &&
         _options?.enabled !== false &&
         enabledQueries.resourceQueries,

--- a/src/lib/hooks/create-stream-client.svelte.ts
+++ b/src/lib/hooks/create-stream-client.svelte.ts
@@ -1,6 +1,10 @@
 import { untrack } from 'svelte';
-import { StreamClient, type streamApi } from '@viamrobotics/sdk';
-import { useRobotClient } from './robot-clients.svelte';
+import {
+  MachineConnectionEvent,
+  StreamClient,
+  type streamApi,
+} from '@viamrobotics/sdk';
+import { useConnectionStatus, useRobotClient } from './robot-clients.svelte';
 import {
   createMutation,
   createQuery,
@@ -20,8 +24,12 @@ export const createStreamClient = (
   let error = $state.raw<Error>();
 
   const client = useRobotClient(partID);
+  const connectionStatus = useConnectionStatus(partID);
   const streamClient = $derived(
-    client.current ? new StreamClient(client.current) : undefined
+    connectionStatus.current === MachineConnectionEvent.CONNECTED &&
+      client.current
+      ? new StreamClient(client.current)
+      : undefined
   );
 
   $effect(() => {


### PR DESCRIPTION
Today when debugging potential connection issues I realized that queries fire before a connection to the machine has been established, which definitely produces waste and makes debugging much more difficult. This fixes that.