### PR TITLE
Feat add config diffing

### DIFF
--- a/.changeset/odd-rules-decide.md
+++ b/.changeset/odd-rules-decide.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/svelte-sdk': patch
+---
+
+fix: issue with config refreshing connections"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "globals": "^16.5.0",
     "jsdom": "^26.1.0",
     "knip": "^6.7.0",
-    "prettier": "^3.8.3",
+    "prettier": "3.6.2",
     "prettier-plugin-svelte": "^3.5.1",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "publint": "^0.3.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
         version: 5.3.1(svelte@5.53.5(@typescript-eslint/types@8.59.1))(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))(vitest@3.2.4(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(yaml@2.8.3))
       '@viamrobotics/prettier-config-svelte':
         specifier: ^1.1.0
-        version: 1.1.0(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1))(tailwindcss@4.2.4)
+        version: 1.1.0(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1))(tailwindcss@4.2.4)
       '@viamrobotics/sdk':
         specifier: ^0.69.0
         version: 0.69.0
@@ -82,14 +82,14 @@ importers:
         specifier: ^6.7.0
         version: 6.7.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       prettier:
-        specifier: ^3.8.3
-        version: 3.8.3
+        specifier: 3.6.2
+        version: 3.6.2
       prettier-plugin-svelte:
         specifier: ^3.5.1
-        version: 3.5.1(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1))
+        version: 3.5.1(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1))
       prettier-plugin-tailwindcss:
         specifier: ^0.6.14
-        version: 0.6.14(prettier-plugin-svelte@3.5.1(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1)))(prettier@3.8.3)
+        version: 0.6.14(prettier-plugin-svelte@3.5.1(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1)))(prettier@3.6.2)
       publint:
         specifier: ^0.3.18
         version: 0.3.18
@@ -2134,8 +2134,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -3527,12 +3527,12 @@ snapshots:
       '@typescript-eslint/types': 8.59.1
       eslint-visitor-keys: 5.0.1
 
-  '@viamrobotics/prettier-config-svelte@1.1.0(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1))(tailwindcss@4.2.4)':
+  '@viamrobotics/prettier-config-svelte@1.1.0(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1))(tailwindcss@4.2.4)':
     dependencies:
-      '@viamrobotics/prettier-config': 1.0.1(prettier@3.8.3)
-      prettier: 3.8.3
-      prettier-plugin-svelte: 3.3.3(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1))
-      prettier-plugin-tailwindcss: 0.6.14(prettier-plugin-svelte@3.3.3(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1)))(prettier@3.8.3)
+      '@viamrobotics/prettier-config': 1.0.1(prettier@3.6.2)
+      prettier: 3.6.2
+      prettier-plugin-svelte: 3.3.3(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1))
+      prettier-plugin-tailwindcss: 0.6.14(prettier-plugin-svelte@3.3.3(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1)))(prettier@3.6.2)
       svelte: 5.53.5(@typescript-eslint/types@8.59.1)
       tailwindcss: 4.2.4
     transitivePeerDependencies:
@@ -3554,9 +3554,9 @@ snapshots:
       - prettier-plugin-sort-imports
       - prettier-plugin-style-order
 
-  '@viamrobotics/prettier-config@1.0.1(prettier@3.8.3)':
+  '@viamrobotics/prettier-config@1.0.1(prettier@3.6.2)':
     dependencies:
-      prettier: 3.8.3
+      prettier: 3.6.2
 
   '@viamrobotics/sdk@0.69.0':
     dependencies:
@@ -4446,31 +4446,31 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.3.3(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1)):
+  prettier-plugin-svelte@3.3.3(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1)):
     dependencies:
-      prettier: 3.8.3
+      prettier: 3.6.2
       svelte: 5.53.5(@typescript-eslint/types@8.59.1)
 
-  prettier-plugin-svelte@3.5.1(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1)):
+  prettier-plugin-svelte@3.5.1(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1)):
     dependencies:
-      prettier: 3.8.3
+      prettier: 3.6.2
       svelte: 5.53.5(@typescript-eslint/types@8.59.1)
 
-  prettier-plugin-tailwindcss@0.6.14(prettier-plugin-svelte@3.3.3(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1)))(prettier@3.8.3):
+  prettier-plugin-tailwindcss@0.6.14(prettier-plugin-svelte@3.3.3(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1)))(prettier@3.6.2):
     dependencies:
-      prettier: 3.8.3
+      prettier: 3.6.2
     optionalDependencies:
-      prettier-plugin-svelte: 3.3.3(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1))
+      prettier-plugin-svelte: 3.3.3(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1))
 
-  prettier-plugin-tailwindcss@0.6.14(prettier-plugin-svelte@3.5.1(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1)))(prettier@3.8.3):
+  prettier-plugin-tailwindcss@0.6.14(prettier-plugin-svelte@3.5.1(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1)))(prettier@3.6.2):
     dependencies:
-      prettier: 3.8.3
+      prettier: 3.6.2
     optionalDependencies:
-      prettier-plugin-svelte: 3.5.1(prettier@3.8.3)(svelte@5.53.5(@typescript-eslint/types@8.59.1))
+      prettier-plugin-svelte: 3.5.1(prettier@3.6.2)(svelte@5.53.5(@typescript-eslint/types@8.59.1))
 
   prettier@2.8.8: {}
 
-  prettier@3.8.3: {}
+  prettier@3.6.2: {}
 
   pretty-format@27.5.1:
     dependencies:

--- a/src/lib/hooks/robot-clients.svelte.ts
+++ b/src/lib/hooks/robot-clients.svelte.ts
@@ -4,11 +4,11 @@ import {
   MachineConnectionEvent,
   RobotClient,
 } from '@viamrobotics/sdk';
-import { getContext, setContext } from 'svelte';
+import { getContext, onMount, setContext } from 'svelte';
 import { useQueryClient } from '@tanstack/svelte-query';
 import type { PartID } from '../part';
 import { logger } from '$lib/logger';
-import { untrack } from 'svelte';
+import { comparePartIds, isJsonEqual } from '../compare';
 
 const robotConnectionsKey = Symbol('robot-connections-context');
 const clientKey = Symbol('clients-context');
@@ -67,6 +67,7 @@ export const provideRobotClientsContext = (
   const queryClient = useQueryClient();
   const robotClients = $state<Record<PartID, RobotConnection | undefined>>({});
   const errors = $state<Record<PartID, Error | undefined>>({});
+  let lastConfigs: Record<PartID, DialConf | undefined> = {};
 
   const disconnect = async (partID: PartID) => {
     if (!robotClients[partID]) {
@@ -152,19 +153,45 @@ export const provideRobotClientsContext = (
   };
 
   $effect(() => {
-    const configs = dialConfigs?.();
-    if (!configs) {
-      return;
+    const configs = dialConfigs?.() ?? {};
+    const { added, removed, unchanged } = comparePartIds(
+      Object.keys(configs),
+      Object.keys(lastConfigs)
+    );
+
+    for (const partID of removed) {
+      disconnect(partID);
     }
 
-    untrack(() => {
-      for (const [partID, config] of Object.entries(configs)) {
+    for (const partID of removed) {
+      disconnect(partID);
+    }
+
+    for (const partID of added) {
+      const config = configs[partID];
+      if (config) {
         connect(partID, config);
       }
-    });
+    }
 
+    for (const partID of unchanged) {
+      const config = configs[partID];
+      const lastConfig = lastConfigs[partID];
+
+      if (config && lastConfig && !isJsonEqual(lastConfig, config)) {
+        logger
+          .withMetadata({ partID })
+          .info('dial config changed, reconnecting');
+        connect(partID, config);
+      }
+    }
+
+    lastConfigs = $state.snapshot(configs) as typeof lastConfigs;
+  });
+
+  onMount(() => {
     return () => {
-      for (const partID of Object.keys(configs)) {
+      for (const partID of Object.keys(dialConfigs?.() ?? {})) {
         disconnect(partID);
       }
     };

--- a/src/lib/hooks/robot-clients.svelte.ts
+++ b/src/lib/hooks/robot-clients.svelte.ts
@@ -163,10 +163,6 @@ export const provideRobotClientsContext = (
       disconnect(partID);
     }
 
-    for (const partID of removed) {
-      disconnect(partID);
-    }
-
     for (const partID of added) {
       const config = configs[partID];
       if (config) {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,6 +5,7 @@ import { ViamProvider } from '$lib';
 import type { Snippet } from 'svelte';
 import { dialConfigs as envConfigs } from './configs';
 import { SDKLogLevel } from '$lib/logger';
+import { onMount } from 'svelte';
 
 interface Props {
   children: Snippet;
@@ -12,7 +13,17 @@ interface Props {
 
 let { children }: Props = $props();
 
-const dialConfigs = $derived(envConfigs);
+let dialConfigs = $state(envConfigs);
+
+onMount(() => {
+  // repro app setup by refreshing dial configs every 1 second
+  const refreshDialConfigs = async () => {
+    dialConfigs = envConfigs;
+  };
+  const interval = setInterval(refreshDialConfigs, 1000);
+  return () => clearInterval(interval);
+});
+
 </script>
 
 <ViamProvider

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -23,7 +23,6 @@ onMount(() => {
   const interval = setInterval(refreshDialConfigs, 1000);
   return () => clearInterval(interval);
 });
-
 </script>
 
 <ViamProvider


### PR DESCRIPTION
# Description

we had an issue where the app re-fetches the dialconfigs every couple seconds and svelte was unable to determine that the values were the same causing us to re-connect to the machine again for identical dial configs. This PR adds back in our custom json diffing to properly connect only when the part dial config changes, otherwise we maintain the old connection across dialConfig refreshes


# Testing
- reproduced app issue by updating the dial config state every one second and saw the spamming of connection issue
- updated to use the json config diffing again and saw the reconnecting go away and previous functionality with explicit disconnect and re-connect is still available


https://github.com/user-attachments/assets/b744eedb-f7e2-402b-8328-131f6314adb2


