### PR TITLE
chore: bump claude-ci-workflows to v2.1.0

### DIFF
--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -30,8 +30,8 @@ jobs:
         github.event.workflow_run.conclusion == 'failure' &&
         startsWith(github.event.workflow_run.head_branch, 'claude/')
       )
-    # viamrobotics/claude-ci-workflows@v2.0.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@aa76787c145ed43f8f7b9bae4d978da4f9850001
+    # viamrobotics/claude-ci-workflows@v2.1.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@97b61edeb3aebf3b9bfc93129ac9beae053e5aab
     with:
       run_id: ${{ github.event.workflow_run.id || inputs.run_id }}
       branch: ${{ github.event.workflow_run.head_branch || inputs.branch }}

--- a/.github/workflows/claude-dependabot-sweep.yml
+++ b/.github/workflows/claude-dependabot-sweep.yml
@@ -16,8 +16,8 @@ jobs:
       issues: write
       id-token: write
     if: github.repository_owner == 'viamrobotics'
-    # viamrobotics/claude-ci-workflows@v2.0.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-dependabot-sweep.yml@aa76787c145ed43f8f7b9bae4d978da4f9850001
+    # viamrobotics/claude-ci-workflows@v2.1.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-dependabot-sweep.yml@97b61edeb3aebf3b9bfc93129ac9beae053e5aab
     with:
       install_command: |
         NODE24_BIN=$(ls -d /opt/hostedtoolcache/node/24.*/x64/bin | tail -1)

--- a/.github/workflows/claude-github-issue.yml
+++ b/.github/workflows/claude-github-issue.yml
@@ -34,8 +34,8 @@ jobs:
           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
         )
       )
-    # viamrobotics/claude-ci-workflows@v2.0.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-github-issue.yml@aa76787c145ed43f8f7b9bae4d978da4f9850001
+    # viamrobotics/claude-ci-workflows@v2.1.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-github-issue.yml@97b61edeb3aebf3b9bfc93129ac9beae053e5aab
     with:
       issue_number: ${{ github.event.issue.number }}
       title: ${{ github.event.issue.title }}

--- a/.github/workflows/claude-jira.yml
+++ b/.github/workflows/claude-jira.yml
@@ -58,8 +58,8 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    # viamrobotics/claude-ci-workflows@v2.0.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@aa76787c145ed43f8f7b9bae4d978da4f9850001
+    # viamrobotics/claude-ci-workflows@v2.1.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@97b61edeb3aebf3b9bfc93129ac9beae053e5aab
     with:
       ticket_id: ${{ github.event.client_payload.ticket_id || inputs.ticket_id }}
       summary: ${{ github.event.client_payload.summary || inputs.summary }}

--- a/.github/workflows/claude-pr-assistant.yml
+++ b/.github/workflows/claude-pr-assistant.yml
@@ -27,8 +27,8 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
         (github.event_name == 'pull_request_review' && github.event.review.state != 'approved' && github.event.review.user.type != 'Bot' && startsWith(github.event.pull_request.head.ref, 'claude/'))
       )
-    # viamrobotics/claude-ci-workflows@v2.0.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@aa76787c145ed43f8f7b9bae4d978da4f9850001
+    # viamrobotics/claude-ci-workflows@v2.1.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@97b61edeb3aebf3b9bfc93129ac9beae053e5aab
     with:
       install_command: |
         NODE24_BIN=$(ls -d /opt/hostedtoolcache/node/24.*/x64/bin | tail -1)


### PR DESCRIPTION
## Summary
Bumps `viamrobotics/claude-ci-workflows` pins (pinned SHA + version comment) from **v2.0.0** to **v2.1.0** (`97b61ed`).

_Reuses the original v2.0.4 bump PR, retargeted to v2.1.0 (branch name unchanged)._

Release: https://github.com/viamrobotics/claude-ci-workflows/releases/tag/v2.1.0

## Changes (v2.0.0 → v2.1.0)
- v2.0.1–v2.0.4 — jira PR-detection fixes (search-index race, bracketed `[TICKET]` prefix), dependabot rebase-job absolute ref, `contents: read` on the jira check-pr job
- **v2.1.0** — deterministic PR creation and always-on execution-log artifacts (#107, #109)

All changes are internal to the reusable workflows — **no `workflow_call` input/secret changes**, so no caller-side edits were required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)