### PR TITLE
Fix a reconnect race condition

### DIFF
--- a/.changeset/reconnect-query-reset-race.md
+++ b/.changeset/reconnect-query-reset-race.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/svelte-sdk': patch
+---
+
+Fix reconnect race where robot data could be wiped while status still reported CONNECTED, by gating connect/disconnect state mutations and the query reset on a per-part connection generation.

--- a/src/lib/components/internal-provider.svelte
+++ b/src/lib/components/internal-provider.svelte
@@ -1,16 +1,23 @@
 <script lang="ts">
 import type { Snippet } from 'svelte';
 import type { DialConf } from '@viamrobotics/sdk';
-import { provideRobotClientsContext } from '$lib/hooks/robot-clients.svelte';
+import {
+  provideRobotClientsContext,
+  type RobotClientsOptions,
+} from '$lib/hooks/robot-clients.svelte';
 
 interface Props {
   dialConfigs: Record<string, DialConf>;
+  options?: RobotClientsOptions | undefined;
   children: Snippet;
 }
 
-let { dialConfigs, children }: Props = $props();
+let { dialConfigs, options, children }: Props = $props();
 
-provideRobotClientsContext(() => dialConfigs);
+provideRobotClientsContext(
+  () => dialConfigs,
+  () => options
+);
 </script>
 
 {@render children()}

--- a/src/lib/components/robot-provider.svelte
+++ b/src/lib/components/robot-provider.svelte
@@ -13,9 +13,11 @@ import {
   type SDKLogLevelType,
   getPersistedLogLevel,
 } from '$lib/logger';
+import type { RobotClientsOptions } from '$lib/hooks/robot-clients.svelte';
 
 interface Props {
   config?: QueryClientConfig;
+  options?: RobotClientsOptions;
   dialConfigs: Record<string, DialConf>;
   logLevel?: SDKLogLevelType;
   children: Snippet;
@@ -25,6 +27,7 @@ let {
   config,
   dialConfigs,
   logLevel = SDKLogLevel.info,
+  options,
   children,
 }: Props = $props();
 
@@ -43,7 +46,10 @@ $effect(() => {
 </script>
 
 <QueryClientProvider {client}>
-  <InternalProvider {dialConfigs}>
+  <InternalProvider
+    {dialConfigs}
+    {options}
+  >
     {@render children()}
   </InternalProvider>
 </QueryClientProvider>

--- a/src/lib/hooks/robot-clients.svelte.ts
+++ b/src/lib/hooks/robot-clients.svelte.ts
@@ -58,16 +58,23 @@ interface RobotConnectionContext {
   connect: (config: DialConf) => Promise<void>;
 }
 
+export interface RobotClientsOptions {
+  resetQueriesOnDisconnect?: boolean;
+}
+
 /**
  * @deprecated `dialConfigs` is deprecated and may be removed in a future release. Users can now explicilty connect and disconnect from robots using the `useRobotClient` and `useRobotClients` hooks.
  */
 export const provideRobotClientsContext = (
-  dialConfigs?: () => Record<PartID, DialConf>
+  dialConfigs?: () => Record<PartID, DialConf>,
+  options?: () => RobotClientsOptions | undefined
 ) => {
   const queryClient = useQueryClient();
   const robotClients = $state<Record<PartID, RobotConnection | undefined>>({});
   const errors = $state<Record<PartID, Error | undefined>>({});
   let lastConfigs: Record<PartID, DialConf | undefined> = {};
+
+  const { resetQueriesOnDisconnect = true } = $derived(options?.() ?? {});
 
   /**
    * Monotonic per-part "generation" token. Both connect() and disconnect() are
@@ -169,23 +176,18 @@ export const provideRobotClientsContext = (
           .withMetadata({ partID, status: newStatus })
           .info('connection state changed');
 
-        if (newStatus === MachineConnectionEvent.DISCONNECTED) {
-          await queryClient.cancelQueries({
-            queryKey: ['viam-svelte-sdk', 'partID', partID],
-          });
-
-          // Re-check after the await: only clear the cache if this connection
-          // is still current AND still disconnected. Otherwise a reset could
-          // land after the connection was superseded or already recovered to
-          // CONNECTED, blanking the UI while the status reads connected.
-          if (
-            !isCurrentGeneration(partID, generation) ||
-            robotClients[partID]?.connectionStatus !==
-              MachineConnectionEvent.DISCONNECTED
-          ) {
-            return;
-          }
-
+        if (
+          newStatus === MachineConnectionEvent.DISCONNECTED &&
+          resetQueriesOnDisconnect
+        ) {
+          // resetQueries() resets each matched query to its initial state, which
+          // synchronously cancels any in-flight fetch (reset -> destroy ->
+          // cancel({ silent: true })) — so a separate cancelQueries() is
+          // redundant. The wipe also runs synchronously at the call site: there
+          // is no await between the generation guard at the top of this listener
+          // and this reset, so the attempt cannot be superseded (nor the
+          // connection recover) in between, and no post-await re-check is needed.
+          // If an await is ever introduced before this reset, restore that check.
           await queryClient.resetQueries({
             queryKey: ['viam-svelte-sdk', 'partID', partID],
           });

--- a/src/lib/hooks/robot-clients.svelte.ts
+++ b/src/lib/hooks/robot-clients.svelte.ts
@@ -91,7 +91,8 @@ export const provideRobotClientsContext = (
     generations[partID] === generation;
 
   const disconnect = async (partID: PartID) => {
-    if (!robotClients[partID]) {
+    const connection = robotClients[partID];
+    if (!connection) {
       return;
     }
 
@@ -99,18 +100,23 @@ export const provideRobotClientsContext = (
     // events from the client we are about to tear down.
     const generation = nextGeneration(partID);
 
+    // Capture the client we are tearing down *before* awaiting. robotClients[partID]
+    // can be reassigned to a newer client while we await (a resuming connect()),
+    // and disconnecting or clearing the listener off the post-await reference would
+    // wipe that newer connection's client instead of ours.
+    const client = connection.client;
+
     logger.withMetadata({ partID }).info('disconnecting');
-    robotClients[partID].connectionStatus =
-      MachineConnectionEvent.DISCONNECTING;
+    connection.connectionStatus = MachineConnectionEvent.DISCONNECTING;
 
     await Promise.all([
-      robotClients[partID].client?.disconnect(),
+      client?.disconnect(),
       queryClient.cancelQueries({
         queryKey: ['viam-svelte-sdk', 'partID', partID],
       }),
     ]);
 
-    robotClients[partID].client?.listeners['connectionstatechange']?.clear();
+    client?.listeners['connectionstatechange']?.clear();
 
     // A newer connect()/disconnect() may have superseded us while we awaited the
     // teardown — if so, leave its state untouched (do not null its client).
@@ -124,12 +130,16 @@ export const provideRobotClientsContext = (
   };
 
   const connect = async (partID: PartID, config: DialConf) => {
-    let generation = 0;
+    // Claim a generation immediately, before disconnect(), so this attempt
+    // supersedes any in-flight connect()/disconnect() right away and the catch
+    // below always has a real generation to check — even if disconnect() throws.
+    let generation = nextGeneration(partID);
     try {
       await disconnect(partID);
 
-      // Claim this attempt's generation once the prior connection is fully torn
-      // down. Every mutation below is gated on it still being current.
+      // disconnect() superseded us with its own generation while tearing the
+      // prior connection down; re-claim before we start mutating state so every
+      // gate below is keyed to this attempt.
       generation = nextGeneration(partID);
 
       const client = new RobotClient();
@@ -200,8 +210,10 @@ export const provideRobotClientsContext = (
         .error('connection failed');
 
       // A superseded attempt's failure must not record an error or flip a newer
-      // connection to DISCONNECTED.
-      if (generation !== 0 && !isCurrentGeneration(partID, generation)) {
+      // connection to DISCONNECTED. If disconnect() threw, our top-of-function
+      // generation was already superseded by disconnect()'s own bump, so this
+      // returns rather than clobbering whatever connection is now current.
+      if (!isCurrentGeneration(partID, generation)) {
         return;
       }
       errors[partID] = error as Error;

--- a/src/lib/hooks/robot-clients.svelte.ts
+++ b/src/lib/hooks/robot-clients.svelte.ts
@@ -69,10 +69,30 @@ export const provideRobotClientsContext = (
   const errors = $state<Record<PartID, Error | undefined>>({});
   let lastConfigs: Record<PartID, DialConf | undefined> = {};
 
+  /**
+   * Monotonic per-part "generation" token. Both connect() and disconnect() are
+   * async and run interleaved with the SDK's own auto-reconnect, so an older
+   * attempt's awaited continuation (a dial resolving, a fire-and-forget reset
+   * from a DISCONNECTED event) can otherwise land after a newer attempt has
+   * already moved the connection on. Claiming a generation at the start of each
+   * attempt and gating every subsequent state mutation on it still being current
+   * ensures a superseded attempt — or events from a client being torn down —
+   * can never clobber the live connection or its query cache.
+   */
+  const generations: Record<PartID, number> = {};
+  const nextGeneration = (partID: PartID) =>
+    (generations[partID] = (generations[partID] ?? 0) + 1);
+  const isCurrentGeneration = (partID: PartID, generation: number) =>
+    generations[partID] === generation;
+
   const disconnect = async (partID: PartID) => {
     if (!robotClients[partID]) {
       return;
     }
+
+    // Supersede any in-flight connect()/disconnect() for this part, and any
+    // events from the client we are about to tear down.
+    const generation = nextGeneration(partID);
 
     logger.withMetadata({ partID }).info('disconnecting');
     robotClients[partID].connectionStatus =
@@ -87,14 +107,26 @@ export const provideRobotClientsContext = (
 
     robotClients[partID].client?.listeners['connectionstatechange']?.clear();
 
+    // A newer connect()/disconnect() may have superseded us while we awaited the
+    // teardown — if so, leave its state untouched (do not null its client).
+    if (!isCurrentGeneration(partID, generation) || !robotClients[partID]) {
+      return;
+    }
+
     robotClients[partID].client = undefined;
     robotClients[partID].connectionStatus = MachineConnectionEvent.DISCONNECTED;
     logger.withMetadata({ partID }).info('disconnected');
   };
 
   const connect = async (partID: PartID, config: DialConf) => {
+    let generation = 0;
     try {
       await disconnect(partID);
+
+      // Claim this attempt's generation once the prior connection is fully torn
+      // down. Every mutation below is gated on it still being current.
+      generation = nextGeneration(partID);
+
       const client = new RobotClient();
       (client as RobotClient & { partID: string }).partID = partID;
 
@@ -107,9 +139,13 @@ export const provideRobotClientsContext = (
       robotClients[partID] = robotClient;
 
       client.on('connectionstatechange', async (event) => {
-        if (!robotClients[partID]) {
+        // Ignore events from a client whose connect attempt has been superseded
+        // — a stale client must not flip a healthy connection to DISCONNECTED
+        // nor wipe its freshly-fetched query data.
+        if (!isCurrentGeneration(partID, generation) || !robotClients[partID]) {
           return;
         }
+
         const newStatus = (event as { eventType: MachineConnectionEvent })
           .eventType;
         robotClients[partID].connectionStatus = newStatus;
@@ -118,13 +154,22 @@ export const provideRobotClientsContext = (
           .withMetadata({ partID, status: newStatus })
           .info('connection state changed');
 
-        if (
-          robotClients[partID].connectionStatus ===
-          MachineConnectionEvent.DISCONNECTED
-        ) {
+        if (newStatus === MachineConnectionEvent.DISCONNECTED) {
           await queryClient.cancelQueries({
             queryKey: ['viam-svelte-sdk', 'partID', partID],
           });
+
+          // Re-check after the await: only clear the cache if this connection
+          // is still current AND still disconnected. Otherwise a reset could
+          // land after the connection was superseded or already recovered to
+          // CONNECTED, blanking the UI while the status reads connected.
+          if (
+            !isCurrentGeneration(partID, generation) ||
+            robotClients[partID]?.connectionStatus !==
+              MachineConnectionEvent.DISCONNECTED
+          ) {
+            return;
+          }
 
           await queryClient.resetQueries({
             queryKey: ['viam-svelte-sdk', 'partID', partID],
@@ -133,8 +178,14 @@ export const provideRobotClientsContext = (
       });
 
       await client.dial(config);
-      errors[partID] = undefined;
 
+      // A newer connect()/disconnect() may have superseded this attempt while we
+      // awaited the dial — if so, do not mark it connected.
+      if (!isCurrentGeneration(partID, generation) || !robotClients[partID]) {
+        return;
+      }
+
+      errors[partID] = undefined;
       robotClients[partID].connectionStatus = MachineConnectionEvent.CONNECTED;
       logger.withMetadata({ partID }).info('connected');
     } catch (error) {
@@ -142,6 +193,12 @@ export const provideRobotClientsContext = (
         .withMetadata({ partID })
         .withError(error)
         .error('connection failed');
+
+      // A superseded attempt's failure must not record an error or flip a newer
+      // connection to DISCONNECTED.
+      if (generation !== 0 && !isCurrentGeneration(partID, generation)) {
+        return;
+      }
       errors[partID] = error as Error;
 
       if (!robotClients[partID]) {

--- a/src/lib/hooks/robot-clients.svelte.ts
+++ b/src/lib/hooks/robot-clients.svelte.ts
@@ -80,8 +80,13 @@ export const provideRobotClientsContext = (
    * can never clobber the live connection or its query cache.
    */
   const generations: Record<PartID, number> = {};
-  const nextGeneration = (partID: PartID) =>
-    (generations[partID] = (generations[partID] ?? 0) + 1);
+
+  const nextGeneration = (partID: PartID) => {
+    const result = (generations[partID] ?? 0) + 1;
+    generations[partID] = result;
+    return result;
+  };
+
   const isCurrentGeneration = (partID: PartID, generation: number) =>
     generations[partID] === generation;
 


### PR DESCRIPTION
Fix a reconnect race where the robot's data could disappear (empty resource names, frames, geometries, etc.) while the connection status still reported `CONNECTED`. `connect()` and `disconnect()` are async and run interleaved with the RobotClient's own auto-reconnect, so an older attempt's continuation — a `dial` resolving, or the fire-and-forget `resetQueries` kicked off by a `DISCONNECTED` event — could land after a newer attempt had already moved the connection on, wiping freshly-fetched query data for the part. Each `connect()`/`disconnect()` now claims a monotonic per-part generation, and every subsequent state mutation (status writes, the `connectionstatechange` listener, and the query reset) is gated on that generation still being current. The `DISCONNECTED` reset also re-checks that the connection is still disconnected after awaiting `cancelQueries`, so it can no longer clobber a connection that has already recovered.