### PR TITLE
fix(stream): remove server-side stream on CameraStream teardown

### DIFF
--- a/.changeset/stream-teardown.md
+++ b/.changeset/stream-teardown.md
@@ -1,0 +1,10 @@
+---
+'@viamrobotics/svelte-sdk': patch
+---
+
+Fix CameraStream teardown so it can be remounted. The stream client now calls
+`StreamClient.remove()` when its effect is destroyed, and stops its getStream
+retry loop once aborted. Previously, unmounting a `CameraStream` left the stream
+registered on the peer connection, so a later remount hit "stream already
+active", never received a track, and looped on the 5s getStream timeout —
+producing a blank video and a flood of AddStream requests.

--- a/src/lib/hooks/create-stream-client.svelte.ts
+++ b/src/lib/hooks/create-stream-client.svelte.ts
@@ -50,9 +50,7 @@ export const createStreamClient = (
           error = undefined;
         }
       } catch (nextError) {
-        // Stop retrying once this effect has been torn down, otherwise the
-        // retry loop outlives the component and keeps calling getStream (and
-        // therefore AddStream) forever.
+        // Don't retry after teardown, or the loop outlives the component.
         if (abortController.signal.aborted) {
           return;
         }
@@ -69,10 +67,7 @@ export const createStreamClient = (
     return () => {
       abortController.abort();
 
-      // Tear down the server-side stream on unmount. Without this the stream
-      // stays registered on the peer connection, so the next mount's AddStream
-      // is rejected as "stream already active", no track is emitted, and
-      // getStream times out on every retry (blank feed + AddStream spam).
+      // Remove the stream server-side so a later remount can re-add it.
       void currentClient?.remove(currentName).catch(() => {});
     };
   });

--- a/src/lib/hooks/create-stream-client.svelte.ts
+++ b/src/lib/hooks/create-stream-client.svelte.ts
@@ -35,16 +35,28 @@ export const createStreamClient = (
   $effect(() => {
     const abortController = new AbortController();
     const currentClient = streamClient;
+    const currentName = name;
 
     const attemptGetStream = async () => {
+      if (abortController.signal.aborted) {
+        return;
+      }
+
       try {
-        const stream = await currentClient?.getStream(name);
+        const stream = await currentClient?.getStream(currentName);
 
         if (!abortController.signal.aborted) {
           mediaStream = stream ?? null;
           error = undefined;
         }
       } catch (nextError) {
+        // Stop retrying once this effect has been torn down, otherwise the
+        // retry loop outlives the component and keeps calling getStream (and
+        // therefore AddStream) forever.
+        if (abortController.signal.aborted) {
+          return;
+        }
+
         error = nextError as Error;
 
         // Retry if a timeout occurs
@@ -56,6 +68,12 @@ export const createStreamClient = (
 
     return () => {
       abortController.abort();
+
+      // Tear down the server-side stream on unmount. Without this the stream
+      // stays registered on the peer connection, so the next mount's AddStream
+      // is rejected as "stream already active", no track is emitted, and
+      // getStream times out on every retry (blank feed + AddStream spam).
+      void currentClient?.remove(currentName).catch(() => {});
     };
   });
 


### PR DESCRIPTION
## Summary

Unmounting and later remounting a `<CameraStream>` (e.g. toggling it behind an `{#if}`) leaves the video permanently blank and floods the machine with `AddStream` requests. `createStreamClient`'s effect never removed the stream on cleanup, and its `getStream` retry loop ignored the abort signal.

## The bug

1. On mount, `getStream(name)` sends `AddStream` and resolves when a matching track event arrives.
2. On unmount, the effect cleanup calls `abortController.abort()` **but never `StreamClient.remove(name)`** — so the stream stays registered on the peer connection.
3. On remount, `AddStream` is rejected server-side as `stream already active` and **no new track is emitted**, so `getStream` can only ever hit its 5s timeout: `Did not receive a stream after 5000 ms`, and a blank `<video>`.
4. The `catch` retries `attemptGetStream()` **without checking `abortController.signal.aborted`**, so every remount/effect-rerun leaks an immortal retry loop. These stack and hammer the robot — observed as tens of thousands of `AddStream` / `stream already active` log lines per minute on a single peer connection.

## Notes / follow-up

Not addressed here to keep the fix focused: the retry loop still has no backoff, so an immediate-reject error path (e.g. a track event with no streams) could spin tightly. Worth a separate look, but it's orthogonal to this teardown bug.