### PR TITLE
Share MediaStream across stream subscribers

### DIFF
--- a/.changeset/tangy-pets-heal.md
+++ b/.changeset/tangy-pets-heal.md
@@ -1,0 +1,5 @@
+---
+"@viamrobotics/svelte-sdk": patch
+---
+
+Share MediaStream across stream subscribers

--- a/src/lib/hooks/__tests__/create-stream-client.svelte.spec.ts
+++ b/src/lib/hooks/__tests__/create-stream-client.svelte.spec.ts
@@ -1,0 +1,78 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import CreateStreamClientTestWrapper from './fixtures/CreateStreamClientTestWrapper.svelte';
+
+const { mockStreamClient, fakeRobotClient } = vi.hoisted(() => ({
+  mockStreamClient: {
+    getStream: vi.fn(),
+    remove: vi.fn(),
+    getOptions: vi.fn(),
+    setOptions: vi.fn(),
+    resetOptions: vi.fn(),
+  },
+  fakeRobotClient: { fakeClient: true },
+}));
+
+vi.mock('@viamrobotics/sdk', () => ({
+  StreamClient: vi.fn(function StreamClient() {
+    return mockStreamClient;
+  }),
+  MachineConnectionEvent: { CONNECTED: 'connected' },
+}));
+
+vi.mock('../robot-clients.svelte', () => ({
+  useRobotClient: () => ({ current: fakeRobotClient }),
+  useConnectionStatus: () => ({ current: 'connected' }),
+}));
+
+vi.mock('../use-enabled-queries.svelte', () => ({
+  useEnabledQueries: () => ({ streams: true }),
+}));
+
+vi.mock('@tanstack/svelte-query', () => ({
+  createQuery: () => ({ data: undefined }),
+  createMutation: () => ({ mutate: vi.fn() }),
+  queryOptions: (opts: unknown) => opts,
+}));
+
+vi.mock('$lib/logger', () => ({
+  createQueryLogger: () => ({
+    request: vi.fn(),
+    response: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const flushMicrotasks = async (rounds = 50) => {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve();
+  }
+};
+
+describe('createStreamClient', () => {
+  beforeEach(() => {
+    mockStreamClient.getStream.mockReset();
+    mockStreamClient.remove.mockReset();
+    mockStreamClient.remove.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('dedupes getStream across subscribers to the same camera', async () => {
+    const fakeStream = {} as MediaStream;
+    mockStreamClient.getStream.mockResolvedValue(fakeStream);
+
+    render(CreateStreamClientTestWrapper, {
+      props: { partID: 'part-1', resourceName: 'camera-1' },
+    });
+    render(CreateStreamClientTestWrapper, {
+      props: { partID: 'part-1', resourceName: 'camera-1' },
+    });
+
+    await flushMicrotasks();
+
+    expect(mockStreamClient.getStream).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/hooks/__tests__/fixtures/CreateStreamClientTestWrapper.svelte
+++ b/src/lib/hooks/__tests__/fixtures/CreateStreamClientTestWrapper.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import { createStreamClient } from '../../create-stream-client.svelte';
+
+interface Props {
+  partID: string;
+  resourceName: string;
+}
+
+let { partID, resourceName }: Props = $props();
+
+const stream = createStreamClient(
+  () => partID,
+  () => resourceName
+);
+</script>
+
+<div data-testid="stream-wrapper">
+  {stream.mediaStream ? 'has-stream' : 'no-stream'}
+  {stream.error ? `error:${stream.error.message}` : ''}
+</div>

--- a/src/lib/hooks/create-stream-client.svelte.ts
+++ b/src/lib/hooks/create-stream-client.svelte.ts
@@ -1,5 +1,6 @@
 import { untrack } from 'svelte';
 import {
+  type Client,
   MachineConnectionEvent,
   StreamClient,
   type streamApi,
@@ -12,6 +13,85 @@ import {
 } from '@tanstack/svelte-query';
 import { createQueryLogger } from '$lib/logger';
 import { useEnabledQueries } from './use-enabled-queries.svelte';
+
+type StreamSubscriber = (
+  mediaStream: MediaStream | null,
+  error: Error | undefined
+) => void;
+
+interface SharedStreamEntry {
+  refCount: number;
+  robotClient: Client;
+  streamClient: StreamClient;
+  mediaStream: MediaStream | null;
+  error: Error | undefined;
+  listeners: Set<StreamSubscriber>;
+  fetchPromise: Promise<void> | null;
+}
+
+const sharedStreams = new Map<string, SharedStreamEntry>();
+
+const acquireSharedStream = (
+  partID: string,
+  resourceName: string,
+  robotClient: Client,
+  subscriber: StreamSubscriber
+): (() => void) => {
+  const key = `${partID}:${resourceName}`;
+  let entry = sharedStreams.get(key);
+
+  // Reconnect: previous connection is dead, drop the entry without remove().
+  if (entry && entry.robotClient !== robotClient) {
+    sharedStreams.delete(key);
+    entry = undefined;
+  }
+
+  if (!entry) {
+    entry = {
+      refCount: 0,
+      robotClient,
+      streamClient: new StreamClient(robotClient),
+      mediaStream: null,
+      error: undefined,
+      listeners: new Set(),
+      fetchPromise: null,
+    };
+    sharedStreams.set(key, entry);
+  }
+
+  const activeEntry = entry;
+  activeEntry.refCount++;
+  activeEntry.listeners.add(subscriber);
+
+  if (activeEntry.mediaStream || activeEntry.error) {
+    subscriber(activeEntry.mediaStream, activeEntry.error);
+  } else if (!activeEntry.fetchPromise) {
+    activeEntry.fetchPromise = (async () => {
+      try {
+        const stream = await activeEntry.streamClient.getStream(resourceName);
+        activeEntry.mediaStream = stream ?? null;
+        activeEntry.error = undefined;
+      } catch (nextError) {
+        activeEntry.mediaStream = null;
+        activeEntry.error = nextError as Error;
+      }
+      for (const listener of activeEntry.listeners) {
+        listener(activeEntry.mediaStream, activeEntry.error);
+      }
+    })();
+  }
+
+  return () => {
+    activeEntry.listeners.delete(subscriber);
+    activeEntry.refCount--;
+    if (activeEntry.refCount === 0) {
+      if (sharedStreams.get(key) === activeEntry) {
+        sharedStreams.delete(key);
+      }
+      void activeEntry.streamClient.remove(resourceName).catch(() => {});
+    }
+  };
+};
 
 export const createStreamClient = (
   partID: () => string,
@@ -33,43 +113,26 @@ export const createStreamClient = (
   );
 
   $effect(() => {
-    const abortController = new AbortController();
-    const currentClient = streamClient;
+    const currentClient = client.current;
     const currentName = name;
+    const currentPartID = partID();
 
-    const attemptGetStream = async () => {
-      if (abortController.signal.aborted) {
-        return;
+    if (
+      connectionStatus.current !== MachineConnectionEvent.CONNECTED ||
+      !currentClient
+    ) {
+      return;
+    }
+
+    return acquireSharedStream(
+      currentPartID,
+      currentName,
+      currentClient,
+      (nextStream, nextError) => {
+        mediaStream = nextStream;
+        error = nextError;
       }
-
-      try {
-        const stream = await currentClient?.getStream(currentName);
-
-        if (!abortController.signal.aborted) {
-          mediaStream = stream ?? null;
-          error = undefined;
-        }
-      } catch (nextError) {
-        // Don't retry after teardown, or the loop outlives the component.
-        if (abortController.signal.aborted) {
-          return;
-        }
-
-        error = nextError as Error;
-
-        // Retry if a timeout occurs
-        attemptGetStream();
-      }
-    };
-
-    attemptGetStream();
-
-    return () => {
-      abortController.abort();
-
-      // Remove the stream server-side so a later remount can re-add it.
-      void currentClient?.remove(currentName).catch(() => {});
-    };
+    );
   });
 
   const queryOptions = $derived(


### PR DESCRIPTION
## Bug
Opening `Quick Test` on a camera that already has a Live subscription in the same tab hangs the panel indefinitely and is only recovery is a full page refresh:

<img width="2555" height="1435" alt="Screenshot 2026-07-27 at 4 47 55 PM" src="https://github.com/user-attachments/assets/9f471fb6-fbeb-4d43-9889-1b80e7d974a2" />

## Root cause
- Two components subscribing to the same camera each open their own StreamClient and race `AddStream` RPCs
- RDK server rejects the loser with `stream already active`
- WebRTC forbids attaching the same track twice to one peer connection, so the fix has to live client-side which in this case makes sense
  
## Fix
- Camera streams are now shared across subscribers with the same `(partID, resourceName)`
- First subscriber calls `getStream` and subsequent subscribers reuse the resulting MediaStream
- Last unsubscribe calls `remove()` and evicts