### PR TITLE
make hooks fallback safely when no provider

### DIFF
--- a/.changeset/provider-optional-hooks.md
+++ b/.changeset/provider-optional-hooks.md
@@ -2,4 +2,4 @@
 '@viamrobotics/svelte-sdk': minor
 ---
 
-Make hooks inert without a ViamProvider/ViamAppProvider ancestor instead of throwing, add an enabled option to useResourceNames, and export a useHasViamProvider probe
+Make hooks inert without a ViamProvider/ViamAppProvider ancestor instead of throwing (queries stay idle, though calling mutate still rejects), add an enabled option to useResourceNames, and export a useHasViamProvider probe for the machine contexts

--- a/.changeset/provider-optional-hooks.md
+++ b/.changeset/provider-optional-hooks.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/svelte-sdk': minor
+---
+
+Make hooks inert without a ViamProvider/ViamAppProvider ancestor instead of throwing, add an enabled option to useResourceNames, and export a useHasViamProvider probe

--- a/src/lib/hooks/__tests__/create-stream-client.svelte.spec.ts
+++ b/src/lib/hooks/__tests__/create-stream-client.svelte.spec.ts
@@ -33,6 +33,8 @@ vi.mock('@tanstack/svelte-query', () => ({
   createQuery: () => ({ data: undefined }),
   createMutation: () => ({ mutate: vi.fn() }),
   queryOptions: (opts: unknown) => opts,
+  useQueryClient: () => ({ fakeQueryClient: true }),
+  QueryClient: vi.fn(),
 }));
 
 vi.mock('$lib/logger', () => ({

--- a/src/lib/hooks/__tests__/fixtures/ProviderOptionalTestWrapper.svelte
+++ b/src/lib/hooks/__tests__/fixtures/ProviderOptionalTestWrapper.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+import type { AppClient } from '@viamrobotics/sdk';
+import {
+  useConnectionStatus,
+  useHasViamProvider,
+  useRobotClient,
+  useRobotConnection,
+} from '../../robot-clients.svelte';
+import { createRobotQuery } from '../../create-robot-query.svelte';
+import { useResourceNames } from '../../resource-names.svelte';
+import { createAppQuery } from '../../app/create-app-query.svelte';
+
+interface Props {
+  onhooks: (hooks: {
+    hasProvider: boolean;
+    robotClient: ReturnType<typeof useRobotClient>;
+    connectionStatus: ReturnType<typeof useConnectionStatus>;
+    robotConnection: ReturnType<typeof useRobotConnection>;
+    robotQuery: ReturnType<typeof createRobotQuery>;
+    resourceNames: ReturnType<typeof useResourceNames>;
+    appQuery: ReturnType<typeof createAppQuery>;
+  }) => void;
+}
+
+let { onhooks }: Props = $props();
+
+const partID = () => 'part-1';
+const client = useRobotClient(partID);
+
+// eslint-disable-next-line svelte/no-unused-svelte-ignore
+// svelte-ignore state_referenced_locally - intentional, reported once at init
+onhooks({
+  hasProvider: useHasViamProvider(),
+  robotClient: client,
+  connectionStatus: useConnectionStatus(partID),
+  robotConnection: useRobotConnection(partID),
+  robotQuery: createRobotQuery(client, 'resourceNames'),
+  resourceNames: useResourceNames(partID),
+  appQuery: createAppQuery<AppClient, 'getRobotPart'>('getRobotPart'),
+});
+</script>
+
+<div data-testid="provider-optional-wrapper">mounted</div>

--- a/src/lib/hooks/__tests__/fixtures/ProviderOptionalTestWrapper.svelte
+++ b/src/lib/hooks/__tests__/fixtures/ProviderOptionalTestWrapper.svelte
@@ -17,6 +17,7 @@ interface Props {
     connectionStatus: ReturnType<typeof useConnectionStatus>;
     robotConnection: ReturnType<typeof useRobotConnection>;
     robotQuery: ReturnType<typeof createRobotQuery>;
+    robotQueryForceEnabled: ReturnType<typeof createRobotQuery>;
     resourceNames: ReturnType<typeof useResourceNames>;
     appQuery: ReturnType<typeof createAppQuery>;
   }) => void;
@@ -35,6 +36,9 @@ onhooks({
   connectionStatus: useConnectionStatus(partID),
   robotConnection: useRobotConnection(partID),
   robotQuery: createRobotQuery(client, 'resourceNames'),
+  robotQueryForceEnabled: createRobotQuery(client, 'resourceNames', () => ({
+    enabled: true,
+  })),
   resourceNames: useResourceNames(partID),
   appQuery: createAppQuery<AppClient, 'getRobotPart'>('getRobotPart'),
 });

--- a/src/lib/hooks/__tests__/fixtures/UseResourceNamesTestWrapper.svelte
+++ b/src/lib/hooks/__tests__/fixtures/UseResourceNamesTestWrapper.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+import { useResourceNames } from '../../resource-names.svelte';
+
+interface Props {
+  enabled?: boolean;
+}
+
+let { enabled }: Props = $props();
+
+useResourceNames(
+  () => 'part-1',
+  undefined,
+  () => (enabled === undefined ? {} : { enabled })
+);
+</script>
+
+<div data-testid="resource-names-wrapper">mounted</div>

--- a/src/lib/hooks/__tests__/provider-optional.svelte.spec.ts
+++ b/src/lib/hooks/__tests__/provider-optional.svelte.spec.ts
@@ -47,6 +47,9 @@ describe('hooks without providers', () => {
 
     expect(hooks.robotQuery.fetchStatus).toBe('idle');
     expect(hooks.robotQuery.data).toBeUndefined();
+    // An explicit `enabled: true` must not bypass the connection guard.
+    expect(hooks.robotQueryForceEnabled.fetchStatus).toBe('idle');
+    expect(hooks.robotQueryForceEnabled.isError).toBe(false);
     expect(hooks.resourceNames.current).toEqual([]);
     expect(hooks.appQuery.fetchStatus).toBe('idle');
     expect(hooks.appQuery.data).toBeUndefined();

--- a/src/lib/hooks/__tests__/provider-optional.svelte.spec.ts
+++ b/src/lib/hooks/__tests__/provider-optional.svelte.spec.ts
@@ -1,0 +1,67 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { describe, it, expect, afterEach } from 'vitest';
+import { MachineConnectionEvent, type DialConf } from '@viamrobotics/sdk';
+import type { ComponentProps } from 'svelte';
+import ProviderOptionalTestWrapper from './fixtures/ProviderOptionalTestWrapper.svelte';
+
+type Hooks = Parameters<
+  ComponentProps<typeof ProviderOptionalTestWrapper>['onhooks']
+>[0];
+
+const renderWithoutProviders = (): Hooks => {
+  let hooks: Hooks | undefined;
+  render(ProviderOptionalTestWrapper, {
+    props: {
+      onhooks: (next) => {
+        hooks = next;
+      },
+    },
+  });
+
+  if (!hooks) {
+    throw new Error('fixture did not report its hooks');
+  }
+
+  return hooks;
+};
+
+describe('hooks without providers', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('mounts without a ViamProvider or ViamAppProvider', () => {
+    const hooks = renderWithoutProviders();
+
+    expect(hooks.hasProvider).toBe(false);
+    expect(hooks.robotClient.current).toBeUndefined();
+    expect(hooks.connectionStatus.current).toBeUndefined();
+    expect(hooks.robotConnection.current).toBeUndefined();
+    expect(hooks.robotConnection.connectionStatus).toBe(
+      MachineConnectionEvent.DISCONNECTED
+    );
+  });
+
+  it('creates queries that stay idle', () => {
+    const hooks = renderWithoutProviders();
+
+    expect(hooks.robotQuery.fetchStatus).toBe('idle');
+    expect(hooks.robotQuery.data).toBeUndefined();
+    expect(hooks.resourceNames.current).toEqual([]);
+    expect(hooks.appQuery.fetchStatus).toBe('idle');
+    expect(hooks.appQuery.data).toBeUndefined();
+  });
+
+  it('resolves connect and disconnect as no-ops', async () => {
+    const hooks = renderWithoutProviders();
+
+    await expect(
+      hooks.robotConnection.connect({ host: 'test' } as DialConf)
+    ).resolves.toBeUndefined();
+    await expect(hooks.robotConnection.disconnect()).resolves.toBeUndefined();
+
+    expect(hooks.robotConnection.connectionStatus).toBe(
+      MachineConnectionEvent.DISCONNECTED
+    );
+  });
+});

--- a/src/lib/hooks/__tests__/resource-names.svelte.spec.ts
+++ b/src/lib/hooks/__tests__/resource-names.svelte.spec.ts
@@ -1,0 +1,54 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import UseResourceNamesTestWrapper from './fixtures/UseResourceNamesTestWrapper.svelte';
+
+const createRobotQueryMock = vi.fn((...args: unknown[]) => {
+  void args;
+  return {
+    data: undefined,
+    refetch: vi.fn(),
+  };
+});
+
+vi.mock('../create-robot-query.svelte', () => ({
+  createRobotQuery: (...args: unknown[]) => createRobotQueryMock(...args),
+}));
+
+type QueryOptions = { enabled?: boolean; refetchInterval?: number };
+
+const optionsOfCall = (call: readonly unknown[]): QueryOptions => {
+  const options = call[2];
+  return (typeof options === 'function' ? options() : options) as QueryOptions;
+};
+
+describe('useResourceNames options', () => {
+  beforeEach(() => {
+    createRobotQueryMock.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('enables both internal queries by default', () => {
+    render(UseResourceNamesTestWrapper, { props: {} });
+
+    const [machineStatusCall] = createRobotQueryMock.mock.calls;
+    expect(machineStatusCall?.[1]).toBe('getMachineStatus');
+    expect(optionsOfCall(machineStatusCall ?? [])).toMatchObject({
+      refetchInterval: 1000,
+      enabled: true,
+    });
+  });
+
+  it('disables both internal queries with enabled: false', () => {
+    render(UseResourceNamesTestWrapper, { props: { enabled: false } });
+
+    const [machineStatusCall, resourceNamesCall] =
+      createRobotQueryMock.mock.calls;
+    expect(machineStatusCall?.[1]).toBe('getMachineStatus');
+    expect(optionsOfCall(machineStatusCall ?? []).enabled).toBe(false);
+    expect(resourceNamesCall?.[1]).toBe('resourceNames');
+    expect(optionsOfCall(resourceNamesCall ?? []).enabled).toBe(false);
+  });
+});

--- a/src/lib/hooks/app/create-app-mutation.svelte.ts
+++ b/src/lib/hooks/app/create-app-mutation.svelte.ts
@@ -4,6 +4,7 @@ import type { AppClient } from '@viamrobotics/sdk';
 import type { ArgumentsType, ResolvedReturnType } from '../queries';
 import { createQueryLogger } from '$lib/logger';
 import { useViamClient } from './use-app-client.svelte';
+import { useSafeQueryClient } from '../use-safe-query-client';
 
 export const createAppMutation = <T extends AppClient, K extends keyof T>(
   method: K
@@ -13,6 +14,7 @@ export const createAppMutation = <T extends AppClient, K extends keyof T>(
 
   const viamClient = useViamClient();
   const appClient = $derived(viamClient.current?.appClient as T);
+  const queryClient = useSafeQueryClient();
 
   const methodName = $derived(String(method));
 
@@ -45,5 +47,8 @@ export const createAppMutation = <T extends AppClient, K extends keyof T>(
     },
   } satisfies MutationOptions<MutReturn, Error, MutArgs>);
 
-  return createMutation(() => mutationOptions);
+  return createMutation(
+    () => mutationOptions,
+    () => queryClient
+  );
 };

--- a/src/lib/hooks/app/create-app-query.svelte.ts
+++ b/src/lib/hooks/app/create-app-query.svelte.ts
@@ -7,6 +7,7 @@ import type { AppClient } from '@viamrobotics/sdk';
 import { usePolling } from '../use-polling.svelte';
 import { createQueryLogger } from '$lib/logger';
 import { useViamClient } from './use-app-client.svelte';
+import { useSafeQueryClient } from '../use-safe-query-client';
 import type {
   ArgumentsType,
   ResolvedReturnType,
@@ -24,6 +25,7 @@ export const createAppQuery = <T extends AppClient, K extends keyof T>(
 ): QueryObserverResult<ResolvedReturnType<T[K]>> => {
   const viamClient = useViamClient();
   const appClient = $derived(viamClient.current?.appClient as T);
+  const queryClient = useSafeQueryClient();
 
   let [args, options] = additional;
 
@@ -89,5 +91,8 @@ export const createAppQuery = <T extends AppClient, K extends keyof T>(
     () => enabled && (_options?.refetchInterval ?? false)
   );
 
-  return createQuery(() => queryOptions);
+  return createQuery(
+    () => queryOptions,
+    () => queryClient
+  );
 };

--- a/src/lib/hooks/app/create-app-query.svelte.ts
+++ b/src/lib/hooks/app/create-app-query.svelte.ts
@@ -51,7 +51,6 @@ export const createAppQuery = <T extends AppClient, K extends keyof T>(
         methodName,
         ...(_args ? [_args] : []),
       ],
-      enabled,
       queryFn: async () => {
         if (!appClient) {
           throw new Error('appClient is undefined');
@@ -82,6 +81,9 @@ export const createAppQuery = <T extends AppClient, K extends keyof T>(
         }
       },
       ..._options,
+      // Pinned after the spread: the computed guard already folds in
+      // `_options?.enabled`, and a caller's `enabled: true` must not bypass it.
+      enabled,
       refetchInterval: false,
     })
   );

--- a/src/lib/hooks/app/create-data-mutation.svelte.ts
+++ b/src/lib/hooks/app/create-data-mutation.svelte.ts
@@ -4,6 +4,7 @@ import type { DataClient } from '@viamrobotics/sdk';
 import type { ArgumentsType, ResolvedReturnType } from '../queries';
 import { createQueryLogger } from '$lib/logger';
 import { useViamClient } from './use-app-client.svelte';
+import { useSafeQueryClient } from '../use-safe-query-client';
 
 export const createDataMutation = <T extends DataClient, K extends keyof T>(
   method: K
@@ -13,6 +14,7 @@ export const createDataMutation = <T extends DataClient, K extends keyof T>(
 
   const viamClient = useViamClient();
   const dataClient = $derived(viamClient.current?.dataClient as T);
+  const queryClient = useSafeQueryClient();
 
   const methodName = $derived(String(method));
 
@@ -45,5 +47,8 @@ export const createDataMutation = <T extends DataClient, K extends keyof T>(
     },
   } satisfies MutationOptions<MutReturn, Error, MutArgs>);
 
-  return createMutation(() => mutationOptions);
+  return createMutation(
+    () => mutationOptions,
+    () => queryClient
+  );
 };

--- a/src/lib/hooks/app/create-data-query.svelte.ts
+++ b/src/lib/hooks/app/create-data-query.svelte.ts
@@ -7,6 +7,7 @@ import type { DataClient } from '@viamrobotics/sdk';
 import { usePolling } from '../use-polling.svelte';
 import { createQueryLogger } from '$lib/logger';
 import { useViamClient } from './use-app-client.svelte';
+import { useSafeQueryClient } from '../use-safe-query-client';
 import type {
   ArgumentsType,
   ResolvedReturnType,
@@ -24,6 +25,7 @@ export const createDataQuery = <T extends DataClient, K extends keyof T>(
 ): QueryObserverResult<ResolvedReturnType<T[K]>> => {
   const viamClient = useViamClient();
   const dataClient = $derived(viamClient.current?.dataClient as T);
+  const queryClient = useSafeQueryClient();
 
   let [args, options] = additional;
 
@@ -89,5 +91,8 @@ export const createDataQuery = <T extends DataClient, K extends keyof T>(
     () => enabled && (_options?.refetchInterval ?? false)
   );
 
-  return createQuery(() => queryOptions);
+  return createQuery(
+    () => queryOptions,
+    () => queryClient
+  );
 };

--- a/src/lib/hooks/app/create-data-query.svelte.ts
+++ b/src/lib/hooks/app/create-data-query.svelte.ts
@@ -51,7 +51,6 @@ export const createDataQuery = <T extends DataClient, K extends keyof T>(
         methodName,
         ...(_args ? [_args] : []),
       ],
-      enabled,
       queryFn: async () => {
         if (!dataClient) {
           throw new Error('dataClient is undefined');
@@ -82,6 +81,9 @@ export const createDataQuery = <T extends DataClient, K extends keyof T>(
         }
       },
       ..._options,
+      // Pinned after the spread: the computed guard already folds in
+      // `_options?.enabled`, and a caller's `enabled: true` must not bypass it.
+      enabled,
       refetchInterval: false,
     })
   );

--- a/src/lib/hooks/app/use-app-client.svelte.ts
+++ b/src/lib/hooks/app/use-app-client.svelte.ts
@@ -60,8 +60,17 @@ export const provideViamClient = (
   });
 };
 
+/**
+ * Returned when no `ViamAppProvider` ancestor exists, so app hooks can mount
+ * without a provider and stay inert.
+ */
+const inertViamClient: Context = {
+  current: undefined,
+  connectionError: undefined,
+};
+
 export const useViamClient = (): {
   current: ViamClient | undefined;
 } => {
-  return getContext<Context>(key);
+  return getContext<Context>(key) ?? inertViamClient;
 };

--- a/src/lib/hooks/create-resource-mutation.svelte.ts
+++ b/src/lib/hooks/create-resource-mutation.svelte.ts
@@ -2,12 +2,12 @@ import {
   createMutation,
   type MutationOptions,
   type QueryKey,
-  useQueryClient,
 } from '@tanstack/svelte-query';
 import type { Resource } from '@viamrobotics/sdk';
 
 import type { ArgumentsType, ResolvedReturnType } from './queries';
 import { createQueryLogger } from '$lib/logger';
+import { useSafeQueryClient } from './use-safe-query-client';
 
 export const createResourceMutation = <T extends Resource, K extends keyof T>(
   client: { current: T | undefined },
@@ -17,7 +17,7 @@ export const createResourceMutation = <T extends Resource, K extends keyof T>(
   type MutArgs = ArgumentsType<T[K]>;
   type MutReturn = ResolvedReturnType<T[K]>;
 
-  const queryClient = useQueryClient();
+  const queryClient = useSafeQueryClient();
   const name = $derived(client.current?.name);
   const methodName = $derived(String(method));
   const key = $derived(queryKey?.());
@@ -82,5 +82,8 @@ export const createResourceMutation = <T extends Resource, K extends keyof T>(
     },
   } satisfies MutationOptions<MutReturn, Error, MutArgs>);
 
-  return createMutation(() => mutationOptions);
+  return createMutation(
+    () => mutationOptions,
+    () => queryClient
+  );
 };

--- a/src/lib/hooks/create-resource-query.svelte.ts
+++ b/src/lib/hooks/create-resource-query.svelte.ts
@@ -65,7 +65,6 @@ export const createResourceQuery = <T extends Resource, K extends keyof T>(
   const queryOptions = $derived(
     createQueryOptions({
       queryKey,
-      enabled,
       retry: false,
       queryFn: async () => {
         const clientFunc = client.current?.[method];
@@ -93,6 +92,9 @@ export const createResourceQuery = <T extends Resource, K extends keyof T>(
         }
       },
       ..._options,
+      // Pinned after the spread: the computed guard already folds in
+      // `_options?.enabled`, and a caller's `enabled: true` must not bypass it.
+      enabled,
       refetchInterval: false,
     })
   );

--- a/src/lib/hooks/create-resource-query.svelte.ts
+++ b/src/lib/hooks/create-resource-query.svelte.ts
@@ -8,6 +8,7 @@ import { usePolling } from './use-polling.svelte';
 import { createQueryLogger } from '$lib/logger';
 import { useEnabledQueries } from './use-enabled-queries.svelte';
 import { useConnectionStatus } from './robot-clients.svelte';
+import { useSafeQueryClient } from './use-safe-query-client';
 import type {
   ArgumentsType,
   ResolvedReturnType,
@@ -27,6 +28,7 @@ export const createResourceQuery = <T extends Resource, K extends keyof T>(
   queryKey: typeof queryKey;
 } => {
   const enabledQueries = useEnabledQueries();
+  const queryClient = useSafeQueryClient();
 
   let [args, options] = additional;
 
@@ -100,9 +102,12 @@ export const createResourceQuery = <T extends Resource, K extends keyof T>(
     () => enabled && (_options?.refetchInterval ?? false)
   );
 
-  const query = createQuery(() => queryOptions) as QueryObserverResult<
-    ResolvedReturnType<T[K]>
-  > & { queryKey: typeof queryKey };
+  const query = createQuery(
+    () => queryOptions,
+    () => queryClient
+  ) as QueryObserverResult<ResolvedReturnType<T[K]>> & {
+    queryKey: typeof queryKey;
+  };
   Object.defineProperty(query, 'queryKey', {
     get: () => queryKey,
     set: () => {

--- a/src/lib/hooks/create-resource-stream.svelte.ts
+++ b/src/lib/hooks/create-resource-stream.svelte.ts
@@ -8,6 +8,7 @@ import { MachineConnectionEvent, type Resource } from '@viamrobotics/sdk';
 import { createQueryLogger } from '$lib/logger';
 import { useEnabledQueries } from './use-enabled-queries.svelte';
 import { useConnectionStatus } from './robot-clients.svelte';
+import { useSafeQueryClient } from './use-safe-query-client';
 import type {
   ArgumentsType,
   StreamItemType,
@@ -42,6 +43,7 @@ export const createResourceStream = <T extends Resource, K extends keyof T>(
     | [options?: (() => QueryOptions) | QueryOptions]
 ): QueryResult<StreamItemType<T[K]>> => {
   const enabledQueries = useEnabledQueries();
+  const queryClient = useSafeQueryClient();
 
   let [args, options] = additional;
 
@@ -103,5 +105,8 @@ export const createResourceStream = <T extends Resource, K extends keyof T>(
     })
   );
 
-  return createQuery(() => queryOptions);
+  return createQuery(
+    () => queryOptions,
+    () => queryClient
+  );
 };

--- a/src/lib/hooks/create-robot-mutation.svelte.ts
+++ b/src/lib/hooks/create-robot-mutation.svelte.ts
@@ -3,6 +3,7 @@ import type { RobotClient } from '@viamrobotics/sdk';
 
 import type { ArgumentsType, ResolvedReturnType } from './queries';
 import { createQueryLogger } from '$lib/logger';
+import { useSafeQueryClient } from './use-safe-query-client';
 
 export const createRobotMutation = <T extends RobotClient, K extends keyof T>(
   client: { current: T | undefined },
@@ -11,6 +12,7 @@ export const createRobotMutation = <T extends RobotClient, K extends keyof T>(
   type MutArgs = ArgumentsType<T[K]>;
   type MutReturn = ResolvedReturnType<T[K]>;
 
+  const queryClient = useSafeQueryClient();
   const methodName = $derived(String(method));
 
   const mutationOptions = $derived({
@@ -48,5 +50,8 @@ export const createRobotMutation = <T extends RobotClient, K extends keyof T>(
     },
   } satisfies MutationOptions<MutReturn, Error, MutArgs>);
 
-  return createMutation(() => mutationOptions);
+  return createMutation(
+    () => mutationOptions,
+    () => queryClient
+  );
 };

--- a/src/lib/hooks/create-robot-query.svelte.ts
+++ b/src/lib/hooks/create-robot-query.svelte.ts
@@ -9,6 +9,7 @@ import { usePolling } from './use-polling.svelte';
 import { createQueryLogger } from '$lib/logger';
 import { useEnabledQueries } from './use-enabled-queries.svelte';
 import { useConnectionStatus } from './robot-clients.svelte';
+import { useSafeQueryClient } from './use-safe-query-client';
 import type {
   ArgumentsType,
   ResolvedReturnType,
@@ -28,6 +29,7 @@ export const createRobotQuery = <T extends RobotClient, K extends keyof T>(
   const partID = $derived((client.current as T & { partID: string })?.partID);
   const connectionStatus = useConnectionStatus(() => partID);
   const enabledQueries = useEnabledQueries();
+  const queryClient = useSafeQueryClient();
   let [args, options] = additional;
 
   if (options === undefined && args !== undefined) {
@@ -94,5 +96,8 @@ export const createRobotQuery = <T extends RobotClient, K extends keyof T>(
     () => enabled && (_options?.refetchInterval ?? false)
   );
 
-  return createQuery(() => queryOptions);
+  return createQuery(
+    () => queryOptions,
+    () => queryClient
+  );
 };

--- a/src/lib/hooks/create-robot-query.svelte.ts
+++ b/src/lib/hooks/create-robot-query.svelte.ts
@@ -59,7 +59,6 @@ export const createRobotQuery = <T extends RobotClient, K extends keyof T>(
         methodName,
         ...(_args ? [_args] : []),
       ],
-      enabled,
       retry: false,
       queryFn: async () => {
         const clientFunc = client.current?.[method];
@@ -87,6 +86,9 @@ export const createRobotQuery = <T extends RobotClient, K extends keyof T>(
         }
       },
       ..._options,
+      // Pinned after the spread: the computed guard already folds in
+      // `_options?.enabled`, and a caller's `enabled: true` must not bypass it.
+      enabled,
       refetchInterval: false,
     })
   );

--- a/src/lib/hooks/create-stream-client.svelte.ts
+++ b/src/lib/hooks/create-stream-client.svelte.ts
@@ -13,6 +13,7 @@ import {
 } from '@tanstack/svelte-query';
 import { createQueryLogger } from '$lib/logger';
 import { useEnabledQueries } from './use-enabled-queries.svelte';
+import { useSafeQueryClient } from './use-safe-query-client';
 
 type StreamSubscriber = (
   mediaStream: MediaStream | null,
@@ -99,6 +100,7 @@ export const createStreamClient = (
 ) => {
   const name = $derived(resourceName());
   const enabledQueries = useEnabledQueries();
+  const queryClient = useSafeQueryClient();
 
   let mediaStream = $state.raw<MediaStream | null>(null);
   let error = $state.raw<Error>();
@@ -171,7 +173,10 @@ export const createStreamClient = (
       },
     })
   );
-  const query = createQuery(() => queryOptions);
+  const query = createQuery(
+    () => queryOptions,
+    () => queryClient
+  );
   const resolutions = $derived(query.data);
 
   const mutationOptions = $derived({
@@ -216,7 +221,10 @@ export const createStreamClient = (
       }
     },
   });
-  const mutation = createMutation(() => mutationOptions);
+  const mutation = createMutation(
+    () => mutationOptions,
+    () => queryClient
+  );
 
   return {
     get current() {

--- a/src/lib/hooks/resource-names.svelte.ts
+++ b/src/lib/hooks/resource-names.svelte.ts
@@ -92,7 +92,6 @@ export const useResourceNames = (
   const query = createRobotQuery(client, 'resourceNames', () => ({
     enabled:
       enabled &&
-      client !== undefined &&
       machineStatus?.data?.state === MachineState.Running &&
       enabledQueries.resourceNames,
     refetchOnMount: false,

--- a/src/lib/hooks/resource-names.svelte.ts
+++ b/src/lib/hooks/resource-names.svelte.ts
@@ -20,6 +20,10 @@ interface QueryContext {
   query: Query | undefined;
 }
 
+export interface ResourceNamesOptions {
+  enabled?: boolean;
+}
+
 const revisions = new Map<string, string>();
 
 const areResourceNamesEqual = (
@@ -69,16 +73,25 @@ const sortResourceNames = (resourceNames: ResourceName[]) => {
 
 export const useResourceNames = (
   partID: () => PartID,
-  resourceSubtype?: string | (() => string)
+  resourceSubtype?: string | (() => string),
+  options?: (() => ResourceNamesOptions) | ResourceNamesOptions
 ): QueryContext => {
   const enabledQueries = useEnabledQueries();
   const client = useRobotClient(partID);
-  const machineStatus = createRobotQuery(client, 'getMachineStatus', {
+
+  const _options = $derived(
+    typeof options === 'function' ? options() : options
+  );
+  const enabled = $derived(_options?.enabled !== false);
+
+  const machineStatus = createRobotQuery(client, 'getMachineStatus', () => ({
     refetchInterval: 1000,
-  });
+    enabled,
+  }));
 
   const query = createRobotQuery(client, 'resourceNames', () => ({
     enabled:
+      enabled &&
       client !== undefined &&
       machineStatus?.data?.state === MachineState.Running &&
       enabledQueries.resourceNames,

--- a/src/lib/hooks/robot-clients.svelte.ts
+++ b/src/lib/hooks/robot-clients.svelte.ts
@@ -5,10 +5,10 @@ import {
   RobotClient,
 } from '@viamrobotics/sdk';
 import { getContext, onMount, setContext } from 'svelte';
-import { useQueryClient } from '@tanstack/svelte-query';
 import type { PartID } from '../part';
 import { logger } from '$lib/logger';
 import { comparePartIds, isJsonEqual } from '../compare';
+import { useSafeQueryClient } from './use-safe-query-client';
 
 const robotConnectionsKey = Symbol('robot-connections-context');
 const clientKey = Symbol('clients-context');
@@ -62,6 +62,19 @@ export interface RobotClientsOptions {
   resetQueriesOnDisconnect?: boolean;
 }
 
+const inertClients: ClientContext = { current: {}, errors: {} };
+const inertConnectionStatuses: ConnectionStatusContext = { current: {} };
+const inertRobotConnections: RobotConnectionsContext = {
+  current: {},
+  errors: {},
+  connect: async (partID: PartID) => {
+    logger
+      .withMetadata({ partID })
+      .warn('connect() called without a ViamProvider ancestor');
+  },
+  disconnect: async () => {},
+};
+
 /**
  * @deprecated `dialConfigs` is deprecated and may be removed in a future release. Users can now explicilty connect and disconnect from robots using the `useRobotClient` and `useRobotClients` hooks.
  */
@@ -69,7 +82,7 @@ export const provideRobotClientsContext = (
   dialConfigs?: () => Record<PartID, DialConf>,
   options?: () => RobotClientsOptions | undefined
 ) => {
-  const queryClient = useQueryClient();
+  const queryClient = useSafeQueryClient();
   const robotClients = $state<Record<PartID, RobotConnection | undefined>>({});
   const errors = $state<Record<PartID, Error | undefined>>({});
   let lastConfigs: Record<PartID, DialConf | undefined> = {};
@@ -312,8 +325,19 @@ export const provideRobotClientsContext = (
   });
 };
 
+/**
+ * Whether a `ViamProvider` ancestor is providing the machine contexts. Lets
+ * consumers distinguish "no provider mounted" (hooks are permanently inert)
+ * from "provider present with no connections".
+ */
+export const useHasViamProvider = (): boolean => {
+  return getContext<ClientContext>(clientKey) !== undefined;
+};
+
 export const useConnectionStatus = (partID: () => PartID) => {
-  const context = getContext<ConnectionStatusContext>(connectionKey);
+  const context =
+    getContext<ConnectionStatusContext>(connectionKey) ??
+    inertConnectionStatuses;
   const status = $derived(context.current[partID()]);
   return {
     get current() {
@@ -323,7 +347,7 @@ export const useConnectionStatus = (partID: () => PartID) => {
 };
 
 export const useRobotClient = (partID: () => PartID) => {
-  const context = getContext<ClientContext>(clientKey);
+  const context = getContext<ClientContext>(clientKey) ?? inertClients;
   const client = $derived(context.current[partID()]);
   return {
     get current() {
@@ -335,7 +359,9 @@ export const useRobotClient = (partID: () => PartID) => {
 export const useRobotConnection = (
   partID: () => PartID
 ): RobotConnectionContext => {
-  const context = getContext<RobotConnectionsContext>(robotConnectionsKey);
+  const context =
+    getContext<RobotConnectionsContext>(robotConnectionsKey) ??
+    inertRobotConnections;
   const client = $derived(context.current[partID()]?.client);
   const error = $derived(context.errors[partID()]);
   const connectionStatus = $derived(

--- a/src/lib/hooks/use-polling.svelte.ts
+++ b/src/lib/hooks/use-polling.svelte.ts
@@ -1,4 +1,4 @@
-import { useQueryClient } from '@tanstack/svelte-query';
+import { useSafeQueryClient } from './use-safe-query-client';
 
 /**
  * Polls a query at an interval while waiting for
@@ -15,7 +15,7 @@ export function usePolling(
   queryKey: () => unknown[],
   interval: () => number | false
 ) {
-  const queryClient = useQueryClient();
+  const queryClient = useSafeQueryClient();
 
   $effect(() => {
     const abortController = new AbortController();

--- a/src/lib/hooks/use-safe-query-client.ts
+++ b/src/lib/hooks/use-safe-query-client.ts
@@ -1,4 +1,5 @@
 import { QueryClient, useQueryClient } from '@tanstack/svelte-query';
+import { logger } from '$lib/logger';
 
 let fallbackQueryClient: QueryClient | undefined;
 
@@ -13,7 +14,12 @@ export const useSafeQueryClient = (): QueryClient => {
   try {
     return useQueryClient();
   } catch {
-    fallbackQueryClient ??= new QueryClient();
+    if (!fallbackQueryClient) {
+      fallbackQueryClient = new QueryClient();
+      logger.warn(
+        'Viam hooks mounted without a ViamProvider/ViamAppProvider ancestor. Queries will not be made.'
+      );
+    }
     return fallbackQueryClient;
   }
 };

--- a/src/lib/hooks/use-safe-query-client.ts
+++ b/src/lib/hooks/use-safe-query-client.ts
@@ -1,0 +1,19 @@
+import { QueryClient, useQueryClient } from '@tanstack/svelte-query';
+
+let fallbackQueryClient: QueryClient | undefined;
+
+/**
+ * `useQueryClient`, tolerating a missing `QueryClientProvider`: hooks mounted
+ * without a `ViamProvider`/`ViamAppProvider` ancestor bind to a shared inert
+ * QueryClient instead of throwing.
+ *
+ * Must be called during component init.
+ */
+export const useSafeQueryClient = (): QueryClient => {
+  try {
+    return useQueryClient();
+  } catch {
+    fallbackQueryClient ??= new QueryClient();
+    return fallbackQueryClient;
+  }
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -10,6 +10,7 @@ export {
   useRobotConnection,
   useConnectionStatus,
   useRobotClient,
+  useHasViamProvider,
 } from './hooks/robot-clients.svelte';
 
 export { createRobotQuery } from './hooks/create-robot-query.svelte';
@@ -27,7 +28,10 @@ export {
   useMachineStatus,
   type ResourceStatus,
 } from './hooks/machine-status.svelte';
-export { useResourceNames } from './hooks/resource-names.svelte';
+export {
+  useResourceNames,
+  type ResourceNamesOptions,
+} from './hooks/resource-names.svelte';
 
 export { usePolling } from './hooks/use-polling.svelte';
 


### PR DESCRIPTION
Makes every hook safe to mount without a `ViamProvider` / `ViamAppProvider` ancestor. Previously, the first hook to run threw TanStack's "No QueryClient was found in Svelte context" (or a `TypeError` from an unguarded `getContext` read), which forced downstream libraries like `@viamrobotics/motion-tools` to require providers even for fully offline embeds.

### Changes

- **Hooks are inert without a provider.** `useRobotClient`, `useConnectionStatus`, and `useRobotConnection` fall back to empty contexts (no clients, `DISCONNECTED` status); `connect()` logs a warning instead of dialing. `useViamClient` falls back to `{ current: undefined }`, making `createAppQuery`/`createAppMutation`/`createDataQuery`/`createDataMutation` provider-optional too. Queries and mutations bind to a shared lazily-created fallback `QueryClient` (passed as the explicit `queryClient` accessor TanStack v6 supports); since every `enabled` chain requires a connected client, nothing ever fetches or polls on it.
- **`useResourceNames` gains an `options` param with `enabled`**, forwarded to both internal queries. This makes its hardcoded 1s `getMachineStatus` poll gateable per call site for the first time.
- **New `useHasViamProvider()` export** so consumers can distinguish "no provider mounted" (hooks permanently inert) from "provider present with no connections" and surface their own diagnostics.

No behavior changes for hosts with providers mounted: with a provider present, the explicit query client resolves to the provider's own client, and `useResourceNames` defaults to enabled.

### Testing

- New `provider-optional.svelte.spec.ts`: robot and app hooks mount with zero providers, queries stay idle (`fetchStatus: 'idle'`, no data), `connect`/`disconnect` resolve as no-ops.
- New `resource-names.svelte.spec.ts`: the `enabled` option reaches both internal queries; defaults keep them enabled.
- `pnpm check`, `pnpm lint`, `pnpm test` (5 files / 23 tests) all green.
